### PR TITLE
chore: add terraform setup and CI pipelines

### DIFF
--- a/.github/workflows/build-deploy-booking-api.yaml
+++ b/.github/workflows/build-deploy-booking-api.yaml
@@ -1,0 +1,33 @@
+name: Build and Deploy Booking API
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'services/booking-api/**'
+      - '.github/workflows/build-deploy-booking-api.yaml'
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      REGION: ${{ secrets.GCP_REGION }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+      - name: Build and Push
+        run: |
+          gcloud builds submit services/booking-api \
+            --tag $REGION-docker.pkg.dev/$PROJECT_ID/services/booking-api:$GITHUB_SHA
+      - name: Deploy
+        run: |
+          gcloud run deploy booking-api \
+            --image $REGION-docker.pkg.dev/$PROJECT_ID/services/booking-api:$GITHUB_SHA \
+            --region $REGION \
+            --platform managed \
+            --quiet

--- a/.github/workflows/build-deploy-core-api.yaml
+++ b/.github/workflows/build-deploy-core-api.yaml
@@ -1,0 +1,33 @@
+name: Build and Deploy Core API
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'services/core-api/**'
+      - '.github/workflows/build-deploy-core-api.yaml'
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      REGION: ${{ secrets.GCP_REGION }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+      - name: Build and Push
+        run: |
+          gcloud builds submit services/core-api \
+            --tag $REGION-docker.pkg.dev/$PROJECT_ID/services/core-api:$GITHUB_SHA
+      - name: Deploy
+        run: |
+          gcloud run deploy core-api \
+            --image $REGION-docker.pkg.dev/$PROJECT_ID/services/core-api:$GITHUB_SHA \
+            --region $REGION \
+            --platform managed \
+            --quiet

--- a/.github/workflows/build-deploy-web.yaml
+++ b/.github/workflows/build-deploy-web.yaml
@@ -1,0 +1,33 @@
+name: Build and Deploy Web
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'web/**'
+      - '.github/workflows/build-deploy-web.yaml'
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+        working-directory: web/kiosk-pwa
+      - name: Build
+        run: npm run build
+        working-directory: web/kiosk-pwa
+      - name: Deploy to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          channelId: live
+          projectId: ${{ env.PROJECT_ID }}
+          target: kiosk

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # zabicekiosk
-kiosk + admin app for online accounting and booking of infant swimming exercises
+
+Kiosk + admin app for online accounting and booking of infant swimming exercises.
+
+## Repository structure
+
+- `infra/` – Terraform configuration for Google Cloud infrastructure.
+- `.github/workflows/` – GitHub Actions pipelines for building and deploying services.
+
+More components will be added as development progresses.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,13 @@
+# Infrastructure
+
+Terraform configuration for Google Cloud resources. The configuration enables Firestore, Identity Platform, Artifact Registry, Cloud Run services and secrets.
+
+## Usage
+
+```sh
+cd terraform
+terraform init
+terraform fmt
+terraform validate
+# terraform plan
+```

--- a/infra/terraform/cloudrun_booking_api.tf
+++ b/infra/terraform/cloudrun_booking_api.tf
@@ -1,0 +1,17 @@
+resource "google_cloud_run_service" "booking_api" {
+  name     = "booking-api"
+  location = var.region
+
+  template {
+    spec {
+      containers {
+        image = "${var.region}-docker.pkg.dev/${var.project_id}/services/booking-api:latest"
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+}

--- a/infra/terraform/cloudrun_core_api.tf
+++ b/infra/terraform/cloudrun_core_api.tf
@@ -1,0 +1,17 @@
+resource "google_cloud_run_service" "core_api" {
+  name     = "core-api"
+  location = var.region
+
+  template {
+    spec {
+      containers {
+        image = "${var.region}-docker.pkg.dev/${var.project_id}/services/core-api:latest"
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+}

--- a/infra/terraform/firebase_hosting.tf
+++ b/infra/terraform/firebase_hosting.tf
@@ -1,0 +1,5 @@
+# Optional Firebase Hosting configuration placeholder
+# resource "google_firebase_hosting_site" "default" {
+#   project = var.project_id
+#   site_id = "kiosk-web"
+# }

--- a/infra/terraform/identity_platform.tf
+++ b/infra/terraform/identity_platform.tf
@@ -1,0 +1,5 @@
+# Placeholder for Identity Platform configuration
+# Enables Google as an identity provider for the admin portal.
+resource "google_identity_platform_config" "default" {
+  project = var.project_id
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# Artifact Registry
+resource "google_artifact_registry_repository" "services" {
+  location      = var.region
+  repository_id = "services"
+  description   = "Container images for services"
+  format        = "DOCKER"
+}
+
+# Firestore enablement
+resource "google_project_service" "firestore" {
+  service = "firestore.googleapis.com"
+}
+
+resource "google_firestore_database" "default" {
+  name        = "(default)"
+  location_id = var.region
+  project     = var.project_id
+  type        = "FIRESTORE_NATIVE"
+  depends_on  = [google_project_service.firestore]
+}
+
+# Identity Platform enablement
+resource "google_project_service" "identity_platform" {
+  service = "identitytoolkit.googleapis.com"
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "artifact_registry_repo" {
+  description = "Artifact Registry repository for container images"
+  value       = google_artifact_registry_repository.services.id
+}

--- a/infra/terraform/secrets.tf
+++ b/infra/terraform/secrets.tf
@@ -1,0 +1,6 @@
+resource "google_secret_manager_secret" "hmac_secret" {
+  secret_id = "HMAC_SECRET"
+  replication {
+    automatic = true
+  }
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,10 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "europe-west1"
+}


### PR DESCRIPTION
## Summary
- scaffold Terraform configuration for GCP services
- add GitHub Actions workflows for core API, booking API, and web frontend

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=infra/terraform init` *(fails: Failed to query available provider packages)*
- `terraform -chdir=infra/terraform validate` *(fails: Missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a422b254832ab96e5c2b252200d3