### PR TITLE
Deploy web apps with Firebase and configure CORS

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,13 @@
+{
+  "projects": {
+    "default": "YOUR_PROJECT_ID"
+  },
+  "targets": {
+    "YOUR_PROJECT_ID": {
+      "hosting": {
+        "kiosk": ["kiosk-web"],
+        "admin": ["admin-web"]
+      }
+    }
+  }
+}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,6 +6,7 @@ steps:
       - -c
       - |
         gcloud services enable firestore.googleapis.com
+
   - id: build-and-deploy-core-api
     name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     entrypoint: bash
@@ -31,6 +32,35 @@ steps:
           --platform managed \
           --allow-unauthenticated \
           --set-env-vars GOOGLE_CLOUD_PROJECT=$PROJECT_ID,FIRESTORE_DATABASE_ID=$_FIRESTORE_DATABASE_ID
+
+  - id: build-kiosk-web
+    name: gcr.io/cloud-builders/npm
+    dir: web/kiosk-pwa
+    args: ['ci']
+
+  - id: build-kiosk-web-build
+    name: gcr.io/cloud-builders/npm
+    dir: web/kiosk-pwa
+    args: ['run', 'build']
+
+  - id: build-admin-web
+    name: gcr.io/cloud-builders/npm
+    dir: web/admin-portal
+    args: ['ci']
+
+  - id: build-admin-web-build
+    name: gcr.io/cloud-builders/npm
+    dir: web/admin-portal
+    args: ['run', 'build']
+
+  - id: deploy-web
+    name: gcr.io/cloud-builders/npm
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        npm install -g firebase-tools
+        firebase deploy --project $PROJECT_ID --only hosting:kiosk,hosting:admin
 
 options:
   logging: CLOUD_LOGGING_ONLY       # или NONE

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,20 @@
+{
+  "hosting": [
+    {
+      "target": "kiosk",
+      "public": "web/kiosk-pwa/dist",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "rewrites": [
+        { "source": "**", "destination": "/index.html" }
+      ]
+    },
+    {
+      "target": "admin",
+      "public": "web/admin-portal/dist",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "rewrites": [
+        { "source": "**", "destination": "/index.html" }
+      ]
+    }
+  ]
+}

--- a/services/booking-api/src/index.ts
+++ b/services/booking-api/src/index.ts
@@ -3,7 +3,8 @@ import cors from '@fastify/cors';
 
 export async function buildServer() {
   const app = Fastify({ logger: true });
-  await app.register(cors, { origin: true });
+  const allowedOrigins = ['https://kiosk-web.web.app', 'https://admin-web.web.app'];
+  await app.register(cors, { origin: allowedOrigins });
 
   app.get('/health', async () => ({ status: 'ok' }));
 

--- a/services/core-api/src/index.ts
+++ b/services/core-api/src/index.ts
@@ -3,7 +3,8 @@ import cors from '@fastify/cors';
 
 export async function buildServer() {
   const app = Fastify({ logger: true });
-  await app.register(cors, { origin: true });
+  const allowedOrigins = ['https://kiosk-web.web.app', 'https://admin-web.web.app'];
+  await app.register(cors, { origin: allowedOrigins });
 
   app.get('/health', async () => ({ status: 'ok' }));
 

--- a/web/admin-portal/.env.example
+++ b/web/admin-portal/.env.example
@@ -1,0 +1,1 @@
+VITE_CORE_API_URL=https://core-api.example.com

--- a/web/admin-portal/src/lib/api.ts
+++ b/web/admin-portal/src/lib/api.ts
@@ -1,5 +1,8 @@
-export async function fetchJSON<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
-  const res = await fetch(input, init);
+const API_BASE_URL = import.meta.env.VITE_CORE_API_URL || '';
+
+export async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
+  const url = path.startsWith('http') ? path : API_BASE_URL + path;
+  const res = await fetch(url, { ...init, mode: 'cors' });
   if (!res.ok) throw new Error(`Request failed: ${res.status}`);
   return res.json() as Promise<T>;
 }

--- a/web/kiosk-pwa/.env.example
+++ b/web/kiosk-pwa/.env.example
@@ -1,0 +1,1 @@
+VITE_CORE_API_URL=https://core-api.example.com

--- a/web/kiosk-pwa/src/lib/api.ts
+++ b/web/kiosk-pwa/src/lib/api.ts
@@ -3,9 +3,12 @@ export interface RedeemResponse {
   message: string;
 }
 
+const API_BASE_URL = import.meta.env.VITE_CORE_API_URL || '';
+
 export async function redeem(token: string): Promise<RedeemResponse> {
-  const res = await fetch('/v1/redeem', {
+  const res = await fetch(`${API_BASE_URL}/v1/redeem`, {
     method: 'POST',
+    mode: 'cors',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ token, kioskId: 'kiosk-1', ts: new Date().toISOString() }),
   });


### PR DESCRIPTION
## Summary
- add Firebase hosting config and build steps to release kiosk and admin web apps via Cloud Build
- expose backend URL via environment variables and enable CORS in web clients
- restrict API services to accept requests only from Firebase-hosted web apps

## Testing
- `npm test --prefix services/core-api`
- `npm test --prefix services/booking-api`
- `npm test --prefix web/kiosk-pwa`
- `npm test --prefix web/admin-portal`
- `npm run build --prefix web/kiosk-pwa`
- `npm run build --prefix web/admin-portal`


------
https://chatgpt.com/codex/tasks/task_e_68a532c6f83c832ab51917b8409bb5e2