### PR TITLE
fix: use Node 20 for firebase deploy

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -34,27 +34,31 @@ steps:
           --set-env-vars GOOGLE_CLOUD_PROJECT=$PROJECT_ID,FIRESTORE_DATABASE_ID=$_FIRESTORE_DATABASE_ID
 
   - id: build-kiosk-web
-    name: gcr.io/cloud-builders/npm
+    name: node:20
+    entrypoint: npm
     dir: web/kiosk-pwa
     args: ['ci']
 
   - id: build-kiosk-web-build
-    name: gcr.io/cloud-builders/npm
+    name: node:20
+    entrypoint: npm
     dir: web/kiosk-pwa
     args: ['run', 'build']
 
   - id: build-admin-web
-    name: gcr.io/cloud-builders/npm
+    name: node:20
+    entrypoint: npm
     dir: web/admin-portal
     args: ['ci']
 
   - id: build-admin-web-build
-    name: gcr.io/cloud-builders/npm
+    name: node:20
+    entrypoint: npm
     dir: web/admin-portal
     args: ['run', 'build']
 
   - id: deploy-web
-    name: gcr.io/cloud-builders/npm
+    name: node:20
     entrypoint: bash
     args:
       - -c


### PR DESCRIPTION
## Summary
- use official Node 20 image for all npm steps
- firebase deploy now runs on Node 20

## Testing
- `cd web/kiosk-pwa && npm test && cd ../../`
- `cd web/admin-portal && npm test && cd ../../`


------
https://chatgpt.com/codex/tasks/task_e_68a5371d4cc0832a975561636512f86a