### PR TITLE
fix: configure firebase project for kiosk hosting

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,9 +1,9 @@
 {
   "projects": {
-    "default": "YOUR_PROJECT_ID"
+    "default": "zabicekiosk"
   },
   "targets": {
-    "YOUR_PROJECT_ID": {
+    "zabicekiosk": {
       "hosting": {
         "kiosk": ["kiosk-web"],
         "admin": ["admin-web"]


### PR DESCRIPTION
## Summary
- configure Firebase project mapping for `zabicekiosk`

## Testing
- `npm test --prefix services/core-api`
- `npm test --prefix web/kiosk-pwa`
- `npm test --prefix web/admin-portal`


------
https://chatgpt.com/codex/tasks/task_e_68a53a3a7f14832aa7f96c32d3624e8f