### PR TITLE
chore: add zabice index to app names

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -5,8 +5,8 @@
   "targets": {
     "zabicekiosk": {
       "hosting": {
-        "kiosk": ["kiosk-web"],
-        "admin": ["admin-web"]
+        "kiosk": ["zabice-kiosk-web"],
+        "admin": ["zabice-admin-web"]
       }
     }
   }

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -33,25 +33,25 @@ steps:
           --allow-unauthenticated \
           --set-env-vars GOOGLE_CLOUD_PROJECT=$PROJECT_ID,FIRESTORE_DATABASE_ID=$_FIRESTORE_DATABASE_ID
 
-  - id: build-kiosk-web
+  - id: build-zabice-kiosk-web
     name: node:20
     entrypoint: npm
     dir: web/kiosk-pwa
     args: ['ci']
 
-  - id: build-kiosk-web-build
+  - id: build-zabice-kiosk-web-build
     name: node:20
     entrypoint: npm
     dir: web/kiosk-pwa
     args: ['run', 'build']
 
-  - id: build-admin-web
+  - id: build-zabice-admin-web
     name: node:20
     entrypoint: npm
     dir: web/admin-portal
     args: ['ci']
 
-  - id: build-admin-web-build
+  - id: build-zabice-admin-web-build
     name: node:20
     entrypoint: npm
     dir: web/admin-portal
@@ -64,8 +64,8 @@ steps:
       - -c
       - |
         npm install -g firebase-tools
-        firebase hosting:sites:create kiosk-web --project $PROJECT_ID || true
-        firebase hosting:sites:create admin-web --project $PROJECT_ID || true
+        firebase hosting:sites:create zabice-kiosk-web --project $PROJECT_ID || true
+        firebase hosting:sites:create zabice-admin-web --project $PROJECT_ID || true
         firebase deploy --project $PROJECT_ID --only hosting:kiosk,hosting:admin
 
 options:

--- a/infra/terraform/firebase_hosting.tf
+++ b/infra/terraform/firebase_hosting.tf
@@ -1,13 +1,13 @@
 # Optional Firebase Hosting configuration placeholder
 # resource "google_firebase_hosting_site" "kiosk" {
 #   project = var.project_id
-#   site_id = "kiosk-web"
+#   site_id = "zabice-kiosk-web"
 # }
 # resource "google_firebase_hosting_site" "admin" {
 #   project = var.project_id
-#   site_id = "admin-web"
+#   site_id = "zabice-admin-web"
 # }
 # resource "google_firebase_hosting_site" "default" {
 #   project = var.project_id
-#   site_id = "kiosk-web"
+#   site_id = "zabice-kiosk-web"
 # }

--- a/services/booking-api/src/index.ts
+++ b/services/booking-api/src/index.ts
@@ -3,7 +3,7 @@ import cors from '@fastify/cors';
 
 export async function buildServer() {
   const app = Fastify({ logger: true });
-  const allowedOrigins = ['https://kiosk-web.web.app', 'https://admin-web.web.app'];
+  const allowedOrigins = ['https://zabice-kiosk-web.web.app', 'https://zabice-admin-web.web.app'];
   await app.register(cors, { origin: allowedOrigins });
 
   app.get('/health', async () => ({ status: 'ok' }));

--- a/services/core-api/src/index.ts
+++ b/services/core-api/src/index.ts
@@ -3,7 +3,7 @@ import cors from '@fastify/cors';
 
 export async function buildServer() {
   const app = Fastify({ logger: true });
-  const allowedOrigins = ['https://kiosk-web.web.app', 'https://admin-web.web.app'];
+  const allowedOrigins = ['https://zabice-kiosk-web.web.app', 'https://zabice-admin-web.web.app'];
   await app.register(cors, { origin: allowedOrigins });
 
   app.get('/health', async () => ({ status: 'ok' }));


### PR DESCRIPTION
## Summary
- include `zabice` in Firebase hosting site names and related configs
- update allowed origins in API services for new hosting domains

## Testing
- `npm test` (services/booking-api)
- `npm test` (services/core-api)


------
https://chatgpt.com/codex/tasks/task_e_68a541120454832a85372c38755e020e