### PR TITLE
Fix core-api missing .js extension for firestore import

### DIFF
--- a/services/core-api/src/routes/admin.users.ts
+++ b/services/core-api/src/routes/admin.users.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
-import { getDb } from '../lib/firestore';
+import { getDb } from '../lib/firestore.js';
 
 export default async function adminUsers(app: FastifyInstance) {
   const db = getDb();


### PR DESCRIPTION
## Summary
- fix module resolution by appending `.js` extension to firestore import

## Testing
- `npm test`
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68a615d8b178832a94bd7a17622f22ff