### PR TITLE
Normalize Instagram handles

### DIFF
--- a/services/core-api/src/routes/admin.clients.ts
+++ b/services/core-api/src/routes/admin.clients.ts
@@ -38,7 +38,18 @@ export default async function adminClients(app: FastifyInstance) {
       .string()
       .trim()
       .optional()
-      .refine(v => !v || /^https?:\/\/([^/]*\.)?instagram\.com\//.test(v), {
+      .transform(v => {
+        if (!v) return undefined;
+        let url = v.trim();
+        if (url.startsWith('@')) {
+          url = url.slice(1);
+        }
+        if (!/^https?:\/\//.test(url)) {
+          url = `https://instagram.com/${url}`;
+        }
+        return url;
+      })
+      .refine(v => !v || /^https?:\/\/([^/]*\.)?instagram\.com\/[A-Za-z0-9._]+\/?$/.test(v), {
         message: 'invalid instagram url',
       }),
   });

--- a/web/admin-portal/src/components/ClientForm.tsx
+++ b/web/admin-portal/src/components/ClientForm.tsx
@@ -42,7 +42,12 @@ export default function ClientForm({ mode, initial, onSubmit, onClose }: Props) 
     }
     if (values.phone) body.phone = normPhone(values.phone);
     if (values.telegram) body.telegram = values.telegram.replace(/^@/, '');
-    if (values.instagram) body.instagram = values.instagram.trim();
+    if (values.instagram) {
+      let ig = values.instagram.trim();
+      if (ig.startsWith('@')) ig = ig.slice(1);
+      if (!/^https?:\/\//.test(ig)) ig = `https://instagram.com/${ig}`;
+      body.instagram = ig;
+    }
     try {
       setBusy(true);
       await onSubmit(body);


### PR DESCRIPTION
## Summary
- Normalize Instagram handles in admin client API to full URL
- Allow admin portal to send Instagram URL for plain handles

## Testing
- `cd services/core-api && npm test`
- `cd web/admin-portal && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a67f63b604832aa66eb950c36d3c64