### PR TITLE
feat(parent-web): add mobile-friendly card styles

### DIFF
--- a/web/parent-web/src/App.css
+++ b/web/parent-web/src/App.css
@@ -1,0 +1,46 @@
+body {
+  margin: 0;
+  background-color: #f9fafb;
+  font-family: system-ui, sans-serif;
+  line-height: 1.5;
+  color: #1a1a1a;
+}
+
+.card-container {
+  max-width: 420px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.card-name {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.card-details p {
+  margin: 0.5rem 0;
+}
+
+.label {
+  font-weight: 600;
+}
+
+.status {
+  text-align: center;
+  margin-top: 2rem;
+}
+
+@media (max-width: 480px) {
+  .card-container {
+    margin: 1rem;
+    padding: 1rem;
+  }
+
+  .card-name {
+    font-size: 1.25rem;
+  }
+}

--- a/web/parent-web/src/App.tsx
+++ b/web/parent-web/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import './App.css';
 
 interface Card {
   name: string;
@@ -25,15 +26,23 @@ export default function App() {
       .catch((e) => setError(e.message));
   }, []);
 
-  if (error) return <p>{error}</p>;
-  if (!card) return <p>Loading...</p>;
+  if (error) return <p className="status">{error}</p>;
+  if (!card) return <p className="status">Loading...</p>;
 
   return (
-    <div>
-      <h1>{card.name}</h1>
-      <p>Plan: {card.planSize}</p>
-      <p>Remaining: {card.remaining}</p>
-      <p>Expires: {new Date(card.expiresAt).toLocaleDateString()}</p>
+    <div className="card-container">
+      <h1 className="card-name">{card.name}</h1>
+      <div className="card-details">
+        <p>
+          <span className="label">Plan:</span> {card.planSize}
+        </p>
+        <p>
+          <span className="label">Remaining:</span> {card.remaining}
+        </p>
+        <p>
+          <span className="label">Expires:</span> {new Date(card.expiresAt).toLocaleDateString()}
+        </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- style parent card page with responsive container and labels
- show loading/error status with centered text

## Testing
- `cd web/parent-web && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a68eee22f0832a96751619aedd0a0f