### PR TITLE
feat(admin): add dark theme and dashboard components

### DIFF
--- a/web/admin-portal/src/components/DataTable.module.css
+++ b/web/admin-portal/src/components/DataTable.module.css
@@ -1,0 +1,5 @@
+.table{width:100%;border-collapse:collapse;font-size:14px;background:var(--panel);border-radius:var(--radius);overflow:hidden;box-shadow:var(--shadow);}
+.table th{background:var(--panel-2);text-align:left;padding:0.5rem;color:var(--text);}
+.table td{padding:0.5rem;}
+.table tbody tr:nth-child(odd){background:#121820;}
+.table tbody tr:nth-child(even){background:var(--panel);}

--- a/web/admin-portal/src/components/DataTable.tsx
+++ b/web/admin-portal/src/components/DataTable.tsx
@@ -1,0 +1,12 @@
+import type { HTMLAttributes, PropsWithChildren } from 'react';
+import styles from './DataTable.module.css';
+
+export default function DataTable(
+  { children, ...rest }: PropsWithChildren<HTMLAttributes<HTMLTableElement>>
+) {
+  return (
+    <table className={styles.table} {...rest}>
+      {children}
+    </table>
+  );
+}

--- a/web/admin-portal/src/components/KpiCard.module.css
+++ b/web/admin-portal/src/components/KpiCard.module.css
@@ -1,0 +1,3 @@
+.card{background:var(--card);border-radius:var(--radius);box-shadow:var(--shadow);padding:1rem;min-width:160px;}
+.title{color:var(--muted);font-size:0.85rem;margin-bottom:0.5rem;}
+.value{font-size:1.5rem;font-weight:bold;color:var(--accent);}

--- a/web/admin-portal/src/components/KpiCard.tsx
+++ b/web/admin-portal/src/components/KpiCard.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+import styles from './KpiCard.module.css';
+
+interface Props {
+  title: string;
+  value: ReactNode;
+}
+
+export default function KpiCard({ title, value }: Props) {
+  return (
+    <div className={styles.card}>
+      <div className={styles.title}>{title}</div>
+      <div className={styles.value}>{value}</div>
+    </div>
+  );
+}

--- a/web/admin-portal/src/components/Layout.module.css
+++ b/web/admin-portal/src/components/Layout.module.css
@@ -1,6 +1,7 @@
-.app{display:flex;min-height:100vh;font-family:sans-serif;}
-.sidebar{width:200px;background:#222;color:#fff;padding:1rem;}
-.navLink{display:block;color:#fff;margin-bottom:0.5rem;text-decoration:none;}
-.active{font-weight:bold;}
-.main{flex:1;padding:1rem;}
-.logout{margin-top:1rem;background:#444;color:#fff;border:none;padding:0.5rem 1rem;cursor:pointer;}
+.app{display:flex;min-height:100vh;background:var(--bg);color:var(--text);}
+.sidebar{width:220px;background:var(--sidebar);padding:1rem;display:flex;flex-direction:column;}
+.navLink{display:block;padding:.5rem 0;color:var(--muted);}
+.navLink:hover{color:var(--text);}
+.active{color:var(--text);font-weight:bold;}
+.main{flex:1;padding:1rem;background:var(--panel);}
+.logout{margin-top:auto;padding:.5rem 1rem;border:none;border-radius:var(--radius);color:var(--text);background:linear-gradient(135deg,var(--accent),var(--accent-2));}

--- a/web/admin-portal/src/components/LineChart.module.css
+++ b/web/admin-portal/src/components/LineChart.module.css
@@ -1,0 +1,2 @@
+.chart{width:100%;height:120px;background:var(--card);border-radius:var(--radius);box-shadow:var(--shadow);}
+.placeholder{display:flex;align-items:center;justify-content:center;height:120px;background:var(--card);color:var(--muted);border-radius:var(--radius);box-shadow:var(--shadow);}

--- a/web/admin-portal/src/components/LineChart.tsx
+++ b/web/admin-portal/src/components/LineChart.tsx
@@ -1,0 +1,32 @@
+import styles from './LineChart.module.css';
+
+interface Point {
+  date: string;
+  count: number;
+}
+
+interface Props {
+  data: Point[];
+}
+
+export default function LineChart({ data }: Props) {
+  if (data.length === 0) return <div className={styles.placeholder}>No data</div>;
+  const max = Math.max(...data.map(d => d.count), 1);
+  const points = data
+    .map((d, i) => {
+      const x = (i / (data.length - 1)) * 100;
+      const y = 100 - (d.count / max) * 100;
+      return `${x},${y}`;
+    })
+    .join(' ');
+  return (
+    <svg viewBox="0 0 100 100" preserveAspectRatio="none" className={styles.chart}>
+      <polyline
+        fill="none"
+        stroke="var(--accent-2)"
+        strokeWidth="3"
+        points={points}
+      />
+    </svg>
+  );
+}

--- a/web/admin-portal/src/index.css
+++ b/web/admin-portal/src/index.css
@@ -1,0 +1,40 @@
+:root {
+  --bg: #0F1115;
+  --sidebar: #171A21;
+  --panel: #12161C;
+  --panel-2: #151A22;
+  --card: #171E27;
+  --text: #EAEFF5;
+  --muted: #9AA5B1;
+  --accent: #2BE090;
+  --accent-2: #4AD6FF;
+  --warn: #FFD166;
+  --error: #FF6B6B;
+  --ok: #2BE090;
+  --radius: 12px;
+  --shadow: 0 8px 24px rgba(0,0,0,.35);
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: system-ui, sans-serif;
+}
+
+a {
+  color: var(--accent-2);
+  text-decoration: none;
+}
+
+button {
+  cursor: pointer;
+}
+
+.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  border: none;
+  border-radius: var(--radius);
+  color: var(--text);
+  padding: 0.5rem 1rem;
+}

--- a/web/admin-portal/src/main.tsx
+++ b/web/admin-portal/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/web/admin-portal/src/pages/Clients.tsx
+++ b/web/admin-portal/src/pages/Clients.tsx
@@ -3,6 +3,7 @@ import { listClients, createClient, updateClient, archiveClient } from '../lib/a
 import type { Client } from '../types';
 import ClientForm from '../components/ClientForm';
 import Confirm from '../components/Confirm';
+import DataTable from '../components/DataTable';
 
 export default function Clients() {
   const [items, setItems] = useState<Client[]>([]);
@@ -120,7 +121,7 @@ export default function Clients() {
           <option value="asc">Asc</option>
           <option value="desc">Desc</option>
         </select>
-        <button onClick={openCreate}>Add client</button>
+        <button onClick={openCreate} className="primary">Add client</button>
       </div>
       {error && <p className="error">{error}</p>}
       {loading ? (
@@ -128,7 +129,7 @@ export default function Clients() {
       ) : items.length === 0 ? (
         <p>No clients yet</p>
       ) : (
-        <table>
+        <DataTable>
           <thead>
             <tr>
               <th>Parent</th>
@@ -160,7 +161,7 @@ export default function Clients() {
               </tr>
             ))}
           </tbody>
-        </table>
+        </DataTable>
       )}
       <div className="pagination">
         <button onClick={gotoPrev} disabled={prevTokens.length === 0}>

--- a/web/admin-portal/src/pages/Dashboard.tsx
+++ b/web/admin-portal/src/pages/Dashboard.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react';
 import { getStats } from '../lib/api';
 import type { Stats } from '../types';
+import KpiCard from '../components/KpiCard';
+import LineChart from '../components/LineChart';
+import DataTable from '../components/DataTable';
 
 export default function Dashboard() {
   const [stats, setStats] = useState<Stats | null>(null);
@@ -16,13 +19,44 @@ export default function Dashboard() {
     <section>
       <h1>Dashboard</h1>
       {error && <p className="error">{error}</p>}
-      {stats ? (
-        <ul>
-          <li>Sales: {stats.sales}</li>
-          <li>Visits: {stats.visits}</li>
-        </ul>
-      ) : (
+      {!stats ? (
         <p>Loading...</p>
+      ) : (
+        <>
+          <div
+            style={{
+              display: 'grid',
+              gap: '1rem',
+              gridTemplateColumns: 'repeat(auto-fit,minmax(160px,1fr))',
+              marginBottom: '1rem',
+            }}
+          >
+            <KpiCard title="Active passes" value={stats.activePasses} />
+            <KpiCard title="Redeems (7d)" value={stats.redeems7d} />
+            <KpiCard title="Drop-in revenue" value={`RSD ${stats.dropInRevenue}`} />
+            <KpiCard title="Expiring (14d)" value={stats.expiring14d} />
+          </div>
+          <LineChart data={stats.redeemsByDay} />
+          <h2 style={{ marginTop: '1rem' }}>Recent redeems</h2>
+          <DataTable>
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Kind</th>
+                <th>Client</th>
+              </tr>
+            </thead>
+            <tbody>
+              {stats.recentRedeems.map(r => (
+                <tr key={r.id}>
+                  <td>{new Date(r.ts).toLocaleString()}</td>
+                  <td>{r.kind}</td>
+                  <td>{r.clientId || ''}</td>
+                </tr>
+              ))}
+            </tbody>
+          </DataTable>
+        </>
       )}
     </section>
   );

--- a/web/admin-portal/src/types.ts
+++ b/web/admin-portal/src/types.ts
@@ -39,6 +39,10 @@ export type Redeem = {
 };
 
 export type Stats = {
-  sales: number;
-  visits: number;
+  activePasses: number;
+  redeems7d: number;
+  dropInRevenue: number;
+  expiring14d: number;
+  redeemsByDay: { date: string; count: number }[];
+  recentRedeems: Redeem[];
 };


### PR DESCRIPTION
## Summary
- add CSS variable palette and base styles for dark theme
- introduce KPI card, line chart, and data table components
- apply new components to dashboard and clients table

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a70e0c4790832ab7ad78ad4a6d225a