### PR TITLE
Generate styled QR codes for client passes

### DIFF
--- a/web/admin-portal/package-lock.json
+++ b/web/admin-portal/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "firebase": "^10.7.1",
+        "qr-code-styling": "^1.8.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.17.0"
@@ -2297,6 +2298,24 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/qr-code-styling": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/qr-code-styling/-/qr-code-styling-1.8.0.tgz",
+      "integrity": "sha512-f6DP31ae/TYWAwjaW0ds7qk+2l7BgPpLW1WDH3t8XSlwXHl8aSvyNQomQ2ra7GC3H9yyNWnjb70jw3KGkFyANw==",
+      "license": "MIT",
+      "dependencies": {
+        "qrcode-generator": "^1.4.4"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/qrcode-generator": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-1.5.2.tgz",
+      "integrity": "sha512-pItrW0Z9HnDBnFmgiNrY1uxRdri32Uh9EjNYLPVC2zZ3ZRIIEqBoDgm4DkvDwNNDHTK7FNkmr8zAa77BYc9xNw==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "18.3.1",

--- a/web/admin-portal/package.json
+++ b/web/admin-portal/package.json
@@ -10,10 +10,11 @@
     "test": "echo 'No tests'"
   },
   "dependencies": {
+    "firebase": "^10.7.1",
+    "qr-code-styling": "^1.8.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.17.0",
-    "firebase": "^10.7.1"
+    "react-router-dom": "^6.17.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",

--- a/web/admin-portal/src/assets/frog.svg
+++ b/web/admin-portal/src/assets/frog.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="30" fill="#4caf50"/>
+  <circle cx="22" cy="24" r="6" fill="#fff"/>
+  <circle cx="42" cy="24" r="6" fill="#fff"/>
+  <circle cx="22" cy="24" r="3" fill="#000"/>
+  <circle cx="42" cy="24" r="3" fill="#000"/>
+  <path d="M20 40c4 4 20 4 24 0" stroke="#000" stroke-width="3" stroke-linecap="round" fill="none"/>
+</svg>

--- a/web/kiosk-pwa/src/pages/Kiosk.tsx
+++ b/web/kiosk-pwa/src/pages/Kiosk.tsx
@@ -29,7 +29,18 @@ export default function Kiosk() {
     setHistory(h => [{ ts: Date.now(), text }, ...h].slice(0, 5));
   };
 
-  const handleToken = async (token: string) => {
+  const extractToken = (raw: string): string => {
+    try {
+      const url = new URL(raw);
+      return url.searchParams.get('token') || raw;
+    } catch {
+      const m = raw.match(/token=([^&]+)/);
+      return m ? decodeURIComponent(m[1]) : raw;
+    }
+  };
+
+  const handleToken = async (raw: string) => {
+    const token = extractToken(raw);
     try {
       const res = await redeem(token);
       if (res.status === 'ok') {


### PR DESCRIPTION
## Summary
- Render QR codes with rounded dots and frog icon when creating client passes
- Encode client card link in QR so kiosks and parents can scan
- Allow kiosk scanner to extract tokens from full URLs

## Testing
- `npm test`
- `npm run build`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a718469404832aa80e048172ce2902