### PR TITLE
feat: list and manage passes with QR

### DIFF
--- a/services/core-api/src/routes/admin.passes.ts
+++ b/services/core-api/src/routes/admin.passes.ts
@@ -8,8 +8,56 @@ import { Timestamp, FieldValue } from '@google-cloud/firestore';
 export default async function adminPasses(app: FastifyInstance) {
   const db = getDb();
 
-  app.get('/passes', { preHandler: requireAdmin }, async () => {
-    return { items: [] };
+  app.get('/passes', { preHandler: requireAdmin }, async req => {
+    const qsSchema = z.object({
+      pageSize: z.coerce.number().min(1).max(50).default(20),
+      pageToken: z.string().optional(),
+      clientId: z.string().optional(),
+    });
+    const { pageSize, pageToken, clientId } = qsSchema.parse(req.query);
+
+    let query: FirebaseFirestore.Query = db.collection('passes').orderBy('purchasedAt', 'desc');
+    if (clientId) query = query.where('clientId', '==', clientId);
+    if (pageToken) {
+      const snap = await db.collection('passes').doc(pageToken).get();
+      if (snap.exists) query = query.startAfter(snap);
+    }
+    const snap = await query.limit(pageSize + 1).get();
+    const docs = snap.docs;
+    const items = await Promise.all(
+      docs.slice(0, pageSize).map(async d => {
+        const data = d.data() as any;
+        const clientSnap = await db.collection('clients').doc(data.clientId).get();
+        const c = clientSnap.data() || {};
+        const item: any = {
+          id: d.id,
+          clientId: data.clientId,
+          planSize: data.planSize,
+          purchasedAt: data.purchasedAt?.toDate?.().toISOString(),
+          remaining: data.planSize - data.used,
+          type: data.planSize === 1 ? 'single' : 'subscription',
+          lastVisit: data.lastRedeemTs?.toDate?.().toISOString(),
+          client: {
+            id: data.clientId,
+            parentName: c.parentName,
+            childName: c.childName,
+            phone: c.phone,
+            telegram: c.telegram,
+            instagram: c.instagram,
+            active: c.active,
+            createdAt: c.createdAt?.toDate?.().toISOString(),
+            updatedAt: c.updatedAt?.toDate?.().toISOString(),
+          },
+        };
+        if (clientId) item.token = data.token;
+        return item;
+      })
+    );
+    let nextPageToken: string | undefined;
+    if (docs.length > pageSize) {
+      nextPageToken = docs[pageSize].id;
+    }
+    return { items, nextPageToken };
   });
 
   app.post('/passes', { preHandler: requireAdmin }, async req => {
@@ -35,10 +83,27 @@ export default async function adminPasses(app: FastifyInstance) {
       purchasedAt,
       expiresAt,
       tokenHash,
+      token: rawToken,
       revoked: false,
       createdAt: FieldValue.serverTimestamp(),
     });
 
     return { rawToken };
   });
+
+  app.get<{ Params: { id: string } }>(
+    '/passes/:id/token',
+    { preHandler: requireAdmin },
+    async req => {
+      const { id } = z.object({ id: z.string() }).parse(req.params);
+      const snap = await db.collection('passes').doc(id).get();
+      if (!snap.exists) {
+        const err: any = new Error('Not Found');
+        err.statusCode = 404;
+        throw err;
+      }
+      const data = snap.data() as any;
+      return { token: data.token };
+    },
+  );
 }

--- a/web/admin-portal/src/lib/api.ts
+++ b/web/admin-portal/src/lib/api.ts
@@ -79,12 +79,18 @@ export async function createPass(body: {
 export async function listPasses(q?: {
   pageSize?: number;
   pageToken?: string;
+  clientId?: string;
 }): Promise<Paginated<PassWithClient>> {
   const params = new URLSearchParams();
   if (q?.pageSize) params.set('pageSize', String(q.pageSize));
   if (q?.pageToken) params.set('pageToken', q.pageToken);
+  if (q?.clientId) params.set('clientId', q.clientId);
   const qs = params.toString();
   return fetchJSON(`/v1/admin/passes${qs ? `?${qs}` : ''}`);
+}
+
+export async function getPassToken(id: string): Promise<{ token: string }> {
+  return fetchJSON(`/v1/admin/passes/${id}/token`);
 }
 
 export async function listRedeems(): Promise<Redeem[]> {

--- a/web/admin-portal/src/types.ts
+++ b/web/admin-portal/src/types.ts
@@ -23,6 +23,7 @@ export type Pass = {
   remaining: number;
   type: 'subscription' | 'single';
   lastVisit?: string;
+  token?: string;
 };
 
 export type PassWithClient = Pass & {


### PR DESCRIPTION
## Summary
- persist pass tokens and expose admin listing
- show existing passes with QR and allow fetching QR codes

## Testing
- `cd services/core-api && npm test`
- `cd web/admin-portal && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7caf401a4832a82f27e8dd3b8ffc2