### PR TITLE
feat(kiosk): add cooldown to QR scanning

### DIFF
--- a/services/core-api/openapi.yaml
+++ b/services/core-api/openapi.yaml
@@ -12,6 +12,12 @@ paths:
   /v1/card:
     get:
       summary: Get public card info
+      parameters:
+        - in: query
+          name: token
+          schema:
+            type: string
+          required: true
       responses:
         '200':
           description: OK

--- a/services/core-api/src/routes/public.card.ts
+++ b/services/core-api/src/routes/public.card.ts
@@ -1,7 +1,38 @@
 import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { getDb } from '../lib/firestore.js';
+import { hashToken } from '../lib/tokens.js';
 
 export default async function publicCard(app: FastifyInstance) {
-  app.get('/card', async () => {
-    return { status: 'ok', message: 'not implemented' };
+  const db = getDb();
+
+  app.get('/card', async (req, reply) => {
+    const qsSchema = z.object({ token: z.string() });
+    const { token } = qsSchema.parse(req.query);
+
+    const tokenHash = hashToken(token);
+    const snap = await db
+      .collection('passes')
+      .where('tokenHash', '==', tokenHash)
+      .where('revoked', '==', false)
+      .limit(1)
+      .get();
+
+    if (snap.empty) {
+      reply.code(404);
+      return { status: 'error', message: 'Not found' };
+    }
+
+    const pass = snap.docs[0].data() as any;
+    const clientSnap = await db.collection('clients').doc(pass.clientId).get();
+    const client = clientSnap.data() as any;
+
+    return {
+      name: client?.childName || client?.parentName || '',
+      planSize: pass.planSize,
+      used: pass.used,
+      remaining: pass.planSize - pass.used,
+      expiresAt: pass.expiresAt.toDate().toISOString(),
+    };
   });
 }

--- a/services/core-api/types/api.d.ts
+++ b/services/core-api/types/api.d.ts
@@ -23,3 +23,11 @@ export type RedeemDropin = {
 export type ErrorPayload = { status: 'error'; code: string; message: string };
 
 export type RedeemResponse = RedeemPass | RedeemDropin | ErrorPayload;
+
+export type CardResponse = {
+  name: string;
+  planSize: number;
+  used: number;
+  remaining: number;
+  expiresAt: string;
+};

--- a/web/kiosk-pwa/src/lib/api.ts
+++ b/web/kiosk-pwa/src/lib/api.ts
@@ -25,7 +25,10 @@ export type RedeemResponse =
   | RedeemDropinResponse
   | RedeemErrorResponse;
 
-const API_BASE_URL = import.meta.env.VITE_CORE_API_URL || '';
+const API_BASE_URL =
+  (import.meta.env.VITE_CORE_API_URL as string | undefined) ??
+  (import.meta.env.VITE_API_BASE as string | undefined) ??
+  '/api';
 
 export async function redeem(token: string): Promise<RedeemResponse> {
   const res = await fetch(`${API_BASE_URL}/v1/redeem`, {

--- a/web/kiosk-pwa/src/lib/barcode.ts
+++ b/web/kiosk-pwa/src/lib/barcode.ts
@@ -1,12 +1,22 @@
-export function scanStream(video: HTMLVideoElement, onToken: (token: string) => void) {
+export function scanStream(
+  video: HTMLVideoElement,
+  onToken: (token: string) => void,
+  cooldownMs = 2000
+) {
   let active = true;
-  const detector = 'BarcodeDetector' in window ? new (window as any).BarcodeDetector({ formats: ['qr_code'] }) : null;
+  const detector =
+    'BarcodeDetector' in window
+      ? new (window as any).BarcodeDetector({ formats: ['qr_code'] })
+      : null;
+  let lastScan = 0;
 
   const scan = async () => {
     if (!active || !detector) return;
     try {
       const codes = await detector.detect(video);
-      if (codes.length) {
+      const now = Date.now();
+      if (codes.length && now - lastScan >= cooldownMs) {
+        lastScan = now;
         onToken(codes[0].rawValue);
       }
     } catch (e) {


### PR DESCRIPTION
## Summary
- avoid rapid re-scans by adding 2 second cooldown to QR barcode detection
- expose `/v1/card` endpoint so QR links show public pass details

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7cfa7cfe4832a975931e192d79a86