### PR TITLE
feat(core-api): add redeems listing and fix passes query

### DIFF
--- a/services/core-api/src/index.ts
+++ b/services/core-api/src/index.ts
@@ -13,6 +13,7 @@ export async function buildServer() {
 
   const adminClients = (await import('./routes/admin.clients.js')).default;
   const adminPasses = (await import('./routes/admin.passes.js')).default;
+  const adminRedeems = (await import('./routes/admin.redeems.js')).default;
   const adminSettings = (await import('./routes/admin.settings.js')).default;
   const adminContent = (await import('./routes/admin.content.js')).default;
   const adminUsers = (await import('./routes/admin.users.js')).default;
@@ -22,6 +23,9 @@ export async function buildServer() {
 
   await app.register(adminPasses, { prefix: '/v1/admin' });
   await app.register(adminPasses, { prefix: '/api/v1/admin' });
+
+  await app.register(adminRedeems, { prefix: '/v1/admin' });
+  await app.register(adminRedeems, { prefix: '/api/v1/admin' });
 
   await app.register(adminSettings, { prefix: '/v1/admin' });
   await app.register(adminSettings, { prefix: '/api/v1/admin' });

--- a/services/core-api/src/routes/admin.redeems.ts
+++ b/services/core-api/src/routes/admin.redeems.ts
@@ -1,0 +1,43 @@
+import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { getDb } from '../lib/firestore.js';
+import { requireAdmin } from '../lib/auth.js';
+
+export default async function adminRedeems(app: FastifyInstance) {
+  const db = getDb();
+
+  app.get('/redeems', { preHandler: requireAdmin }, async req => {
+    const qsSchema = z.object({
+      pageSize: z.coerce.number().min(1).max(50).default(20),
+      pageToken: z.string().optional(),
+    });
+    const { pageSize, pageToken } = qsSchema.parse(req.query);
+
+    let query: FirebaseFirestore.Query = db
+      .collection('redeems')
+      .orderBy('ts', 'desc');
+    if (pageToken) {
+      const snap = await db.collection('redeems').doc(pageToken).get();
+      if (snap.exists) query = query.startAfter(snap);
+    }
+    const snap = await query.limit(pageSize + 1).get();
+    const docs = snap.docs;
+    const items = docs.slice(0, pageSize).map(d => {
+      const data = d.data() as any;
+      return {
+        id: d.id,
+        ts: data.ts?.toDate?.().toISOString(),
+        kind: data.kind,
+        clientId: data.clientId,
+        delta: data.delta,
+        priceRSD: data.priceRSD,
+      };
+    });
+    let nextPageToken: string | undefined;
+    if (docs.length > pageSize) {
+      nextPageToken = docs[pageSize].id;
+    }
+    return { items, nextPageToken };
+  });
+}
+


### PR DESCRIPTION
## Summary
- add admin redeems route and register it
- avoid Firestore composite index requirement when listing passes for a client

## Testing
- `npm test` (services/core-api)
- `npm test` (web/admin-portal)


------
https://chatgpt.com/codex/tasks/task_e_68a7d5fc83d8832aa6caa1df63723397