### PR TITLE
fix(core-api,web): standardize API base path

### DIFF
--- a/services/core-api/openapi.yaml
+++ b/services/core-api/openapi.yaml
@@ -3,13 +3,13 @@ info:
   title: core-api
   version: 0.1.0
 paths:
-  /v1/redeem:
+  /api/v1/redeem:
     post:
       summary: Redeem pass or record drop-in
       responses:
         '200':
           description: OK
-  /v1/card:
+  /api/v1/card:
     get:
       summary: Get public card info
       parameters:

--- a/services/core-api/src/index.ts
+++ b/services/core-api/src/index.ts
@@ -8,8 +8,8 @@ export async function buildServer() {
 
   app.get('/health', async () => ({ status: 'ok' }));
 
-  await app.register(import('./routes/public.card.js'), { prefix: '/v1' });
-  await app.register(import('./routes/public.redeem.js'), { prefix: '/v1' });
+  await app.register(import('./routes/public.card.js'), { prefix: '/api/v1' });
+  await app.register(import('./routes/public.redeem.js'), { prefix: '/api/v1' });
 
   const adminClients = (await import('./routes/admin.clients.js')).default;
   const adminPasses = (await import('./routes/admin.passes.js')).default;
@@ -18,22 +18,16 @@ export async function buildServer() {
   const adminContent = (await import('./routes/admin.content.js')).default;
   const adminUsers = (await import('./routes/admin.users.js')).default;
 
-  await app.register(adminClients, { prefix: '/v1/admin' });
   await app.register(adminClients, { prefix: '/api/v1/admin' });
 
-  await app.register(adminPasses, { prefix: '/v1/admin' });
   await app.register(adminPasses, { prefix: '/api/v1/admin' });
 
-  await app.register(adminRedeems, { prefix: '/v1/admin' });
   await app.register(adminRedeems, { prefix: '/api/v1/admin' });
 
-  await app.register(adminSettings, { prefix: '/v1/admin' });
   await app.register(adminSettings, { prefix: '/api/v1/admin' });
 
-  await app.register(adminContent, { prefix: '/v1/admin' });
   await app.register(adminContent, { prefix: '/api/v1/admin' });
 
-  await app.register(adminUsers, { prefix: '/v1/admin' });
   await app.register(adminUsers, { prefix: '/api/v1/admin' });
 
   return app;

--- a/web/admin-portal/src/lib/api.ts
+++ b/web/admin-portal/src/lib/api.ts
@@ -4,7 +4,6 @@ import type { Client, Paginated, PassWithClient, Redeem, Stats } from '../types'
 
 const API_BASE_URL =
   (import.meta.env.VITE_CORE_API_URL as string | undefined) ??
-  (import.meta.env.VITE_API_BASE as string | undefined) ??
   '/api'; // безопасный дефолт
 
 export async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {

--- a/web/kiosk-pwa/src/lib/api.ts
+++ b/web/kiosk-pwa/src/lib/api.ts
@@ -27,7 +27,6 @@ export type RedeemResponse =
 
 const API_BASE_URL =
   (import.meta.env.VITE_CORE_API_URL as string | undefined) ??
-  (import.meta.env.VITE_API_BASE as string | undefined) ??
   '/api';
 
 export async function redeem(token: string): Promise<RedeemResponse> {


### PR DESCRIPTION
## Summary
- expose core API under `/api/v1` and drop confusing `/v1` aliases
- remove `VITE_API_BASE` fallback to ensure clients default to `/api`
- update OpenAPI spec for new base path

## Testing
- `cd services/core-api && npm test`
- `cd web/kiosk-pwa && npm test`
- `cd web/admin-portal && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7dbead2e8832a8bdcc509e1c46f89