### PR TITLE
fix(admin): ensure API requests ask for JSON

### DIFF
--- a/web/admin-portal/src/lib/api.ts
+++ b/web/admin-portal/src/lib/api.ts
@@ -11,6 +11,7 @@ export async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T>
   const headers = new Headers(init?.headers);
   const token = await getIdToken();
   if (token) headers.set('Authorization', `Bearer ${token}`);
+  if (!headers.has('Accept')) headers.set('Accept', 'application/json');
   const res = await fetch(url, { ...init, headers, credentials: 'include' });
 
   const ct = res.headers.get('content-type') || '';


### PR DESCRIPTION
## Summary
- request JSON responses in admin portal API client

## Testing
- `cd web/admin-portal && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8f5c7fec4832a84f6c2a12d1d5ff1