### PR TITLE
fix: ensure API base URL includes version path

### DIFF
--- a/web/admin-portal/src/lib/api.ts
+++ b/web/admin-portal/src/lib/api.ts
@@ -2,9 +2,12 @@
 import { getIdToken } from './auth';
 import type { Client, Paginated, PassWithClient, Redeem, Stats } from '../types';
 
-const API_BASE_URL =
-  (import.meta.env.VITE_CORE_API_URL as string | undefined) ??
-  '/api/v1'; // безопасный дефолт
+const API_BASE_URL = (() => {
+  const env = import.meta.env.VITE_CORE_API_URL as string | undefined;
+  if (!env) return '/api/v1';
+  const base = env.replace(/\/$/, '');
+  return base.endsWith('/api/v1') ? base : `${base}/api/v1`;
+})();
 
 export async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
   const url = path.startsWith('http') ? path : `${API_BASE_URL}${path}`;


### PR DESCRIPTION
## Summary
- handle `VITE_CORE_API_URL` with or without trailing slash and ensure `/api/v1` prefix

## Testing
- `cd web/admin-portal && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8fdeea0ec832a97a7ac08600099e3