### PR TITLE
feat: increase QR cooldown and block duplicate redemption

### DIFF
--- a/services/core-api/src/lib/business.ts
+++ b/services/core-api/src/lib/business.ts
@@ -56,12 +56,24 @@ export async function redeem(
       return { status: 'error', code: 'EXPIRED', message: 'Pass expired' };
     }
 
-    const cooldownSec = settings?.cooldownSec ?? 0;
+    const cooldownSec = settings?.cooldownSec ?? 5;
     if (
       pass.lastRedeemTs &&
       now.seconds - pass.lastRedeemTs.seconds < cooldownSec
     ) {
       return { status: 'error', code: 'COOLDOWN', message: 'Try later' };
+    }
+
+    const daySec = 24 * 60 * 60;
+    if (
+      pass.lastRedeemTs &&
+      now.seconds - pass.lastRedeemTs.seconds < daySec
+    ) {
+      return {
+        status: 'error',
+        code: 'DUPLICATE',
+        message: 'Занятие уже учтено',
+      };
     }
 
     const remaining = pass.planSize - pass.used;

--- a/web/kiosk-pwa/src/lib/barcode.ts
+++ b/web/kiosk-pwa/src/lib/barcode.ts
@@ -1,7 +1,7 @@
 export function scanStream(
   video: HTMLVideoElement,
   onToken: (token: string) => void,
-  cooldownMs = 2000
+  cooldownMs = 5000
 ) {
   let active = true;
   const detector =


### PR DESCRIPTION
## Summary
- extend QR scanner cooldown to 5 seconds in kiosk PWA
- prevent repeated redemptions within 24 hours and return "Занятие уже учтено"

## Testing
- `npm test` (web/kiosk-pwa)
- `npm test` (services/core-api)


------
https://chatgpt.com/codex/tasks/task_e_68a9068a5104832a92f1f8ea0e7057a8