### PR TITLE
feat: add pass revocation and avoid duplicates

### DIFF
--- a/web/admin-portal/src/components/ClientForm.tsx
+++ b/web/admin-portal/src/components/ClientForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import type { Client } from '../types';
-import { createPass, listPasses } from '../lib/api';
+import { createPass, listPasses, deletePass } from '../lib/api';
 import QRCodeStyling from 'qr-code-styling';
 import frog from '../assets/frog.svg';
 
@@ -18,7 +18,7 @@ function normPhone(v: string) {
   return '+381' + digits.replace(/^0+/, '');
 }
 
-function PassDisplay({ token, url }: { token: string; url: string }) {
+function PassDisplay({ token, url, onDelete }: { token: string; url: string; onDelete: () => void }) {
   const ref = useRef<HTMLDivElement>(null);
   const qrCode = useRef<QRCodeStyling | null>(null);
 
@@ -98,6 +98,9 @@ function PassDisplay({ token, url }: { token: string; url: string }) {
       <button type="button" onClick={handleShare}>
         Send to Telegram
       </button>
+      <button type="button" onClick={onDelete}>
+        Delete
+      </button>
     </div>
   );
 }
@@ -139,6 +142,15 @@ export default function ClientForm({ mode, initial, onSubmit, onClose }: Props) 
         setPasses(ps);
       })
       .catch(e => setPassMsg(e.message || String(e)));
+  };
+
+  const handleDeletePass = async (id: string) => {
+    try {
+      await deletePass(id);
+      loadPasses();
+    } catch (e: any) {
+      setPassMsg(e.message || String(e));
+    }
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -240,7 +252,12 @@ export default function ClientForm({ mode, initial, onSubmit, onClose }: Props) 
             {passes.length > 0 && (
               <div className="pass-list">
                 {passes.map(p => (
-                  <PassDisplay key={p.id} token={p.token} url={p.url} />
+                  <PassDisplay
+                    key={p.id}
+                    token={p.token}
+                    url={p.url}
+                    onDelete={() => handleDeletePass(p.id)}
+                  />
                 ))}
               </div>
             )}

--- a/web/admin-portal/src/lib/api.ts
+++ b/web/admin-portal/src/lib/api.ts
@@ -96,6 +96,10 @@ export async function getPassToken(id: string): Promise<{ token: string }> {
   return fetchJSON(`/admin/passes/${id}/token`);
 }
 
+export async function deletePass(id: string): Promise<void> {
+  await fetchJSON(`/admin/passes/${id}`, { method: 'DELETE' });
+}
+
 export async function listRedeems(): Promise<Redeem[]> {
   const res = await fetchJSON<{ items: Redeem[] }>(`/admin/redeems`);
   return res.items;


### PR DESCRIPTION
## Summary
- ensure pass creation returns existing token when active pass exists
- allow revoking passes and filter out revoked ones for client view
- expose delete pass endpoint and UI in admin panel

## Testing
- `cd services/core-api && npm test`
- `cd web/admin-portal && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9087c6284832a865cb096a21d8dca