### PR TITLE
chore: add parent web Firebase hosting

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -6,7 +6,8 @@
     "zabicekiosk": {
       "hosting": {
         "kiosk": ["zabice-kiosk-web"],
-        "admin": ["zabice-admin-web"]
+        "admin": ["zabice-admin-web"],
+        "parent": ["zabice-parent-web"]
       }
     }
   }

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -57,6 +57,18 @@ steps:
     dir: web/admin-portal
     args: ['run', 'build']
 
+  - id: build-zabice-parent-web
+    name: node:20
+    entrypoint: npm
+    dir: web/parent-web
+    args: ['ci']
+
+  - id: build-zabice-parent-web-build
+    name: node:20
+    entrypoint: npm
+    dir: web/parent-web
+    args: ['run', 'build']
+
   - id: deploy-web
     name: node:20
     entrypoint: bash
@@ -66,7 +78,8 @@ steps:
         npm install -g firebase-tools
         firebase hosting:sites:create zabice-kiosk-web --project $PROJECT_ID || true
         firebase hosting:sites:create zabice-admin-web --project $PROJECT_ID || true
-        firebase deploy --project $PROJECT_ID --only hosting:kiosk,hosting:admin
+        firebase hosting:sites:create zabice-parent-web --project $PROJECT_ID || true
+        firebase deploy --project $PROJECT_ID --only hosting:kiosk,hosting:admin,hosting:parent
 
 options:
   logging: CLOUD_LOGGING_ONLY       # или NONE

--- a/firebase.json
+++ b/firebase.json
@@ -19,6 +19,16 @@
         { "source": "/booking/**", "run": { "serviceId": "booking-api", "region": "europe-west3" } },
         { "source": "**", "destination": "/index.html" }
       ]
+    },
+    {
+      "target": "parent",
+      "public": "web/parent-web/dist",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "rewrites": [
+        { "source": "/api/**", "run": { "serviceId": "core-api",    "region": "europe-west3" } },
+        { "source": "/booking/**", "run": { "serviceId": "booking-api", "region": "europe-west3" } },
+        { "source": "**", "destination": "/index.html" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- configure Firebase hosting for parent web
- extend Cloud Build to build and deploy parent app

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a911669d48832ab0d6e4ef1a87bb67