### PR TITLE
feat(kiosk): show success overlay and toggleable log

### DIFF
--- a/web/kiosk-pwa/src/pages/Kiosk.module.css
+++ b/web/kiosk-pwa/src/pages/Kiosk.module.css
@@ -3,6 +3,8 @@
   flex-direction: column;
   align-items: center;
   gap: 1rem;
+  position: relative;
+  min-height: 100vh;
 }
 .offline {
   background: #dc2626;
@@ -12,12 +14,36 @@
 }
 .history {
   list-style: none;
-  padding: 0;
+  padding: 0.5rem;
   margin: 0;
   width: 360px;
+  position: absolute;
+  bottom: 3rem;
+  left: 0;
+  background: rgba(255, 255, 255, 0.9);
 }
 .history li {
   font-size: 0.9rem;
   border-bottom: 1px solid #ddd;
   padding: 2px 0;
+}
+.logToggle {
+  position: absolute;
+  bottom: 0.5rem;
+  left: 0.5rem;
+}
+.successOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(209, 250, 229, 0.9);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  font-size: 2rem;
+  z-index: 10;
 }


### PR DESCRIPTION
## Summary
- highlight kiosk screen with greeting and visit info after successful scan
- add toggleable scanner log hidden by default

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a913bf4438832a8d7a62417143e087