### PR TITLE
Show only active passes per client

### DIFF
--- a/web/admin-portal/src/pages/Passes.tsx
+++ b/web/admin-portal/src/pages/Passes.tsx
@@ -14,7 +14,15 @@ export default function Passes() {
   useEffect(() => {
     setLoading(true);
     listPasses()
-      .then(res => setItems(res.items))
+      .then(res => {
+        const unique = new Map<string, PassWithClient>();
+        for (const p of res.items) {
+          if (p.remaining > 0 && !unique.has(p.clientId)) {
+            unique.set(p.clientId, p);
+          }
+        }
+        setItems(Array.from(unique.values()));
+      })
       .catch(e => setError(e.message))
       .finally(() => setLoading(false));
   }, []);


### PR DESCRIPTION
## Summary
- filter passes to hide redeemed ones
- ensure only one active pass is shown per client

## Testing
- `cd web/admin-portal && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a916d4d6f8832a91558011ebd2a880