### PR TITLE
Show client names on Redeems page

### DIFF
--- a/web/admin-portal/src/pages/Redeems.tsx
+++ b/web/admin-portal/src/pages/Redeems.tsx
@@ -30,7 +30,17 @@ export default function Redeems() {
             <tr key={r.id}>
               <td>{new Date(r.ts).toLocaleString()}</td>
               <td>{r.kind}</td>
-              <td>{r.clientId || '-'}</td>
+              <td>
+                {r.client ? (
+                  <>
+                    {r.client.parentName} / {r.client.childName}
+                    <br />
+                    <small>{r.clientId}</small>
+                  </>
+                ) : (
+                  r.clientId || '-'
+                )}
+              </td>
               <td>{r.delta ?? r.priceRSD ?? ''}</td>
             </tr>
           ))}

--- a/web/admin-portal/src/types.ts
+++ b/web/admin-portal/src/types.ts
@@ -37,6 +37,7 @@ export type Redeem = {
   clientId?: string;
   delta?: number;
   priceRSD?: number;
+  client?: Client;
 };
 
 export type Stats = {


### PR DESCRIPTION
## Summary
- include full client data in admin redeems API
- display client name alongside ID in admin portal Redeems list
- extend Redeem type to expose optional client info

## Testing
- `cd services/core-api && npm test`
- `cd web/admin-portal && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9179eeca8832abaa1d04f10e04af3