### PR TITLE
fix scanner cooldown

### DIFF
--- a/web/kiosk-pwa/src/components/CameraScanner.tsx
+++ b/web/kiosk-pwa/src/components/CameraScanner.tsx
@@ -8,7 +8,13 @@ interface Props {
 
 export default function CameraScanner({ onToken }: Props) {
   const videoRef = useRef<HTMLVideoElement>(null);
+  const onTokenRef = useRef(onToken);
   const [facingMode, setFacingMode] = useState<'user' | 'environment'>('user');
+
+  // keep latest onToken without reinitialising scanner
+  useEffect(() => {
+    onTokenRef.current = onToken;
+  }, [onToken]);
 
   useEffect(() => {
     let localStream: MediaStream | null = null;
@@ -20,7 +26,7 @@ export default function CameraScanner({ onToken }: Props) {
         if (videoRef.current) {
           videoRef.current.srcObject = stream;
           videoRef.current.play();
-          stopScan = scanStream(videoRef.current, onToken);
+          stopScan = scanStream(videoRef.current, token => onTokenRef.current(token));
         }
       })
       .catch(err => console.error(err));
@@ -28,7 +34,7 @@ export default function CameraScanner({ onToken }: Props) {
       stopScan();
       if (localStream) localStream.getTracks().forEach(t => t.stop());
     };
-  }, [onToken, facingMode]);
+  }, [facingMode]);
 
   const toggleCamera = () => {
     setFacingMode(f => (f === 'user' ? 'environment' : 'user'));


### PR DESCRIPTION
## Summary
- keep latest `onToken` via ref to avoid reinitialising scanner
- ensure QR code scanner respects cooldown period

## Testing
- `cd web/kiosk-pwa && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a919074ad4832ab29ebca7ae2ed3a7