### PR TITLE
chore: cancel previous pipeline runs

### DIFF
--- a/.github/workflows/build-deploy-booking-api.yaml
+++ b/.github/workflows/build-deploy-booking-api.yaml
@@ -7,6 +7,10 @@ on:
       - 'services/booking-api/**'
       - '.github/workflows/build-deploy-booking-api.yaml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-deploy-core-api.yaml
+++ b/.github/workflows/build-deploy-core-api.yaml
@@ -7,6 +7,10 @@ on:
       - 'services/core-api/**'
       - '.github/workflows/build-deploy-core-api.yaml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-deploy-web.yaml
+++ b/.github/workflows/build-deploy-web.yaml
@@ -7,6 +7,10 @@ on:
       - 'web/**'
       - '.github/workflows/build-deploy-web.yaml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,14 @@
 steps:
+  - id: cancel-previous-builds
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        gcloud builds list --ongoing --filter 'tags="zabicekiosk"' --format='value(id)' \
+        | grep -v "$BUILD_ID" \
+        | xargs -r gcloud builds cancel
+
   - id: enable-firestore-api
     name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     entrypoint: bash
@@ -88,3 +98,6 @@ options:
 substitutions:
   _REGION: europe-west3
   _FIRESTORE_DATABASE_ID: "zabicedb"
+
+tags:
+  - zabicekiosk


### PR DESCRIPTION
## Summary
- cancel in-progress builds when new commits trigger the same workflow
- stop existing Cloud Build runs for the same pipeline before starting a new one

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a919b2e3b0832a84e5542051d31ac0