### PR TITLE
feat: extract token from QR code URL

### DIFF
--- a/web/admin-portal/src/components/ClientForm.tsx
+++ b/web/admin-portal/src/components/ClientForm.tsx
@@ -133,7 +133,7 @@ export default function ClientForm({ mode, initial, onSubmit, onClose }: Props) 
       .then(res => {
         const base =
           (import.meta.env.VITE_CARD_URL_BASE as string | undefined) ||
-          window.location.origin + '/card';
+          window.location.origin.replace('admin', 'parent');
         const ps = res.items.map(p => ({
           id: p.id,
           token: p.token!,

--- a/web/admin-portal/src/pages/Passes.tsx
+++ b/web/admin-portal/src/pages/Passes.tsx
@@ -48,7 +48,7 @@ export default function Passes() {
       const res = await getPassToken(id);
       const base =
         (import.meta.env.VITE_CARD_URL_BASE as string | undefined) ||
-        window.location.origin + '/card';
+        window.location.origin.replace('admin', 'parent');
       const url = `${base}?token=${encodeURIComponent(res.token)}`;
       setQr({ token: res.token, url });
     } catch (e: any) {

--- a/web/kiosk-pwa/src/pages/Kiosk.tsx
+++ b/web/kiosk-pwa/src/pages/Kiosk.tsx
@@ -30,19 +30,8 @@ export default function Kiosk() {
   const pushHistory = (text: string) => {
     setHistory(h => [{ ts: Date.now(), text }, ...h].slice(0, 5));
   };
-
-  const extractToken = (raw: string): string => {
-    try {
-      const url = new URL(raw);
-      return url.searchParams.get('token') || raw;
-    } catch {
-      const m = raw.match(/token=([^&]+)/);
-      return m ? decodeURIComponent(m[1]) : raw;
-    }
-  };
-
-  const handleToken = async (raw: string) => {
-    const token = extractToken(raw);
+  
+  const handleToken = async (token: string) => {
     try {
       const res = await redeem(token);
       if (res.status === 'ok') {


### PR DESCRIPTION
## Summary
- parse token or id from scanned QR code URLs in CameraScanner
- simplify kiosk page to accept only tokens
- generate QR codes in admin portal that point to the parent site

## Testing
- `cd web/admin-portal && npm test`
- `cd web/kiosk-pwa && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a91d611ce8832a824c68c9889fbacb