### PR TITLE
feat: generate client QR codes and simplify pass management

### DIFF
--- a/services/core-api/src/routes/public.redeem.ts
+++ b/services/core-api/src/routes/public.redeem.ts
@@ -3,11 +3,17 @@ import { z } from 'zod';
 import { validate } from '../lib/validation.js';
 import { redeem } from '../lib/business.js';
 
-const RedeemRequestSchema = z.object({
-  token: z.string(),
-  kioskId: z.string(),
-  ts: z.string(),
-});
+const RedeemRequestSchema = z
+  .object({
+    token: z.string().optional(),
+    clientId: z.string().optional(),
+    kioskId: z.string(),
+    ts: z.string(),
+  })
+  .refine(d => d.token || d.clientId, {
+    message: 'token or clientId required',
+    path: ['token'],
+  });
 
 export default async function publicRedeem(app: FastifyInstance) {
   app.post('/redeem', async (req) => {

--- a/services/core-api/types/api.d.ts
+++ b/services/core-api/types/api.d.ts
@@ -1,5 +1,6 @@
 export type RedeemRequest = {
-  token: string;
+  token?: string;
+  clientId?: string;
   kioskId: string;
   ts: string;
 };
@@ -13,16 +14,15 @@ export type RedeemPass = {
   expiresAt: string;
 };
 
-export type RedeemDropin = {
+export type RedeemSingle = {
   status: 'ok';
-  type: 'dropin';
+  type: 'single';
   message: string;
-  priceRSD: number;
 };
 
 export type ErrorPayload = { status: 'error'; code: string; message: string };
 
-export type RedeemResponse = RedeemPass | RedeemDropin | ErrorPayload;
+export type RedeemResponse = RedeemPass | RedeemSingle | ErrorPayload;
 
 export type CardResponse = {
   name: string;

--- a/web/admin-portal/src/pages/Passes.tsx
+++ b/web/admin-portal/src/pages/Passes.tsx
@@ -1,15 +1,11 @@
-import { useEffect, useRef, useState } from 'react';
-import { listPasses, getClientToken } from '../lib/api';
-import QRCodeStyling from 'qr-code-styling';
-import frog from '../assets/frog.svg';
+import { useEffect, useState } from 'react';
+import { listPasses } from '../lib/api';
 import type { PassWithClient } from '../types';
 
 export default function Passes() {
   const [items, setItems] = useState<PassWithClient[]>([]);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
-  const [qr, setQr] = useState<{ token: string; url: string } | null>(null);
-  const qrRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setLoading(true);
@@ -27,34 +23,7 @@ export default function Passes() {
       .finally(() => setLoading(false));
   }, []);
 
-  useEffect(() => {
-    if (!qr || !qrRef.current) return;
-    const qrCode = new QRCodeStyling({
-      width: 200,
-      height: 200,
-      type: 'svg',
-      data: qr.url,
-      image: frog,
-      dotsOptions: { type: 'rounded' },
-      cornersSquareOptions: { type: 'extra-rounded' },
-      imageOptions: { margin: 4 },
-    });
-    qrRef.current.innerHTML = '';
-    qrCode.append(qrRef.current);
-  }, [qr]);
-
-  const openQr = async (clientId: string) => {
-    try {
-      const res = await getClientToken(clientId);
-      const base =
-        (import.meta.env.VITE_CARD_URL_BASE as string | undefined) ||
-        window.location.origin.replace('admin', 'parent');
-      const url = `${base}?token=${encodeURIComponent(res.token)}`;
-      setQr({ token: res.token, url });
-    } catch (e: any) {
-      setError(e.message || String(e));
-    }
-  };
+  // QR codes are shown on client cards only
 
   return (
     <section>
@@ -73,7 +42,7 @@ export default function Passes() {
               <th>Type</th>
               <th>Remaining</th>
               <th>Last visit</th>
-              <th></th>
+              
             </tr>
           </thead>
           <tbody>
@@ -88,26 +57,13 @@ export default function Passes() {
                   {p.remaining}/{p.planSize}
                 </td>
                 <td>{p.lastVisit ? new Date(p.lastVisit).toLocaleDateString() : '-'}</td>
-                <td>
-                  <button onClick={() => openQr(p.clientId)}>Get QR Code</button>
-                </td>
+                
               </tr>
             ))}
           </tbody>
         </table>
       )}
-      {qr && (
-        <div className="modal">
-          <div className="modal-body">
-            <h3>Pass QR</h3>
-            <div ref={qrRef}></div>
-            <p>
-              <code>{qr.token}</code>
-            </p>
-            <button onClick={() => setQr(null)}>Close</button>
-          </div>
-        </div>
-      )}
+      
     </section>
   );
 }

--- a/web/kiosk-pwa/src/components/Toast.tsx
+++ b/web/kiosk-pwa/src/components/Toast.tsx
@@ -1,7 +1,7 @@
 import styles from './Toast.module.css';
 
 interface Props {
-  kind: 'pass' | 'dropin' | 'cooldown' | 'out' | 'error';
+  kind: 'pass' | 'cooldown' | 'out' | 'error';
   message: string;
 }
 

--- a/web/kiosk-pwa/src/lib/api.ts
+++ b/web/kiosk-pwa/src/lib/api.ts
@@ -7,11 +7,10 @@ export interface RedeemPassResponse {
   expiresAt: string;
 }
 
-export interface RedeemDropinResponse {
+export interface RedeemSingleResponse {
   status: 'ok';
-  type: 'dropin';
+  type: 'single';
   message: string;
-  priceRSD: number;
 }
 
 export interface RedeemErrorResponse {
@@ -22,14 +21,17 @@ export interface RedeemErrorResponse {
 
 export type RedeemResponse =
   | RedeemPassResponse
-  | RedeemDropinResponse
+  | RedeemSingleResponse
   | RedeemErrorResponse;
 
 const API_BASE_URL =
   (import.meta.env.VITE_CORE_API_URL as string | undefined) ??
   '/api/v1';
 
-export async function redeem(token: string): Promise<RedeemResponse> {
+export async function redeem(data: {
+  token?: string;
+  clientId?: string;
+}): Promise<RedeemResponse> {
   const res = await fetch(`${API_BASE_URL}/redeem`, {
     method: 'POST',
     mode: 'cors',
@@ -37,7 +39,7 @@ export async function redeem(token: string): Promise<RedeemResponse> {
       'Content-Type': 'application/json',
       'Idempotency-Key': crypto.randomUUID(),
     },
-    body: JSON.stringify({ token, kioskId: 'kiosk-1', ts: new Date().toISOString() }),
+    body: JSON.stringify({ ...data, kioskId: 'kiosk-1', ts: new Date().toISOString() }),
   });
   return res.json();
 }

--- a/web/kiosk-pwa/src/pages/Kiosk.tsx
+++ b/web/kiosk-pwa/src/pages/Kiosk.tsx
@@ -31,15 +31,19 @@ export default function Kiosk() {
     setHistory(h => [{ ts: Date.now(), text }, ...h].slice(0, 5));
   };
   
-  const handleToken = async (token: string) => {
+  const handleToken = async (data: string) => {
     try {
-      const res = await redeem(token);
+      const payload: { token?: string; clientId?: string } = {};
+      const match = data.match(/token=([^&]+)/);
+      if (match) payload.token = decodeURIComponent(match[1]);
+      else payload.clientId = data;
+      const res = await redeem(payload);
       if (res.status === 'ok') {
         let details: string;
         if (res.type === 'pass') {
           details = `Занятие учтено. Осталось ${res.remaining} занятий.`;
         } else {
-          details = `Занятие учтено. К оплате ${res.priceRSD} RSD.`;
+          details = `Разовое занятие.`;
         }
         setSuccessInfo({ greeting: res.message, details });
         pushHistory(details);


### PR DESCRIPTION
## Summary
- generate and display client QR codes with direct card links
- streamline admin pass management and remove pass QR button
- allow kiosk redeem by client id and handle one-time visits

## Testing
- `npm test` in `services/core-api`
- `npm test` in `web/admin-portal`
- `npm test` in `web/kiosk-pwa`
- `npm run build` in `web/kiosk-pwa`
- `npm run build` in `web/admin-portal`


------
https://chatgpt.com/codex/tasks/task_e_68a92724b628832a852c19cc93ecc3bb