### PR TITLE
feat: add jsQR fallback for barcode scanning

### DIFF
--- a/web/kiosk-pwa/package-lock.json
+++ b/web/kiosk-pwa/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kiosk-pwa",
       "version": "0.1.0",
       "dependencies": {
+        "jsqr": "^1.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -1331,6 +1332,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",

--- a/web/kiosk-pwa/package.json
+++ b/web/kiosk-pwa/package.json
@@ -10,6 +10,7 @@
     "test": "echo 'No tests'"
   },
   "dependencies": {
+    "jsqr": "^1.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/web/kiosk-pwa/src/lib/barcode.ts
+++ b/web/kiosk-pwa/src/lib/barcode.ts
@@ -1,3 +1,5 @@
+import jsQR from 'jsqr';
+
 export function scanStream(
   video: HTMLVideoElement,
   onToken: (token: string) => void,
@@ -8,16 +10,30 @@ export function scanStream(
     'BarcodeDetector' in window
       ? new (window as any).BarcodeDetector({ formats: ['qr_code'] })
       : null;
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
   let lastScan = 0;
 
   const scan = async () => {
-    if (!active || !detector) return;
+    if (!active) return;
     try {
-      const codes = await detector.detect(video);
       const now = Date.now();
-      if (codes.length && now - lastScan >= cooldownMs) {
-        lastScan = now;
-        onToken(codes[0].rawValue);
+      if (detector) {
+        const codes = await detector.detect(video);
+        if (codes.length && now - lastScan >= cooldownMs) {
+          lastScan = now;
+          onToken(codes[0].rawValue);
+        }
+      } else if (ctx) {
+        canvas.width = video.videoWidth;
+        canvas.height = video.videoHeight;
+        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+        const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+        const code = jsQR(imageData.data, canvas.width, canvas.height);
+        if (code && now - lastScan >= cooldownMs) {
+          lastScan = now;
+          onToken(code.data);
+        }
       }
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
## Summary
- use BarcodeDetector when available and fall back to jsQR
- include jsqr dependency

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9397c30fc832ab9801a44e49bba59