### PR TITLE
feat(parent-web): show QR code on client card

### DIFF
--- a/web/parent-web/package-lock.json
+++ b/web/parent-web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "parent-web",
       "version": "0.1.0",
       "dependencies": {
+        "qrcode.react": "^4.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -1421,6 +1422,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react": {

--- a/web/parent-web/package.json
+++ b/web/parent-web/package.json
@@ -10,6 +10,7 @@
     "test": "echo 'No tests'"
   },
   "dependencies": {
+    "qrcode.react": "^4.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/web/parent-web/src/App.css
+++ b/web/parent-web/src/App.css
@@ -29,6 +29,12 @@ body {
   font-weight: 600;
 }
 
+.card-qr {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: center;
+}
+
 .status {
   text-align: center;
   margin-top: 2rem;

--- a/web/parent-web/src/App.tsx
+++ b/web/parent-web/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { QRCodeCanvas } from 'qrcode.react';
 import './App.css';
 
 interface Card {
@@ -12,19 +13,19 @@ interface Card {
 export default function App() {
   const [card, setCard] = useState<Card | null>(null);
   const [error, setError] = useState('');
+  const params = new URLSearchParams(window.location.search);
+  const token = params.get('token') || '';
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const token = params.get('token') || '';
     if (!token) {
       setError('Missing token');
       return;
     }
-      fetch(`/api/v1/card?token=${encodeURIComponent(token)}`)
+    fetch(`/api/v1/card?token=${encodeURIComponent(token)}`)
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error('Failed'))))
       .then((data: Card) => setCard(data))
       .catch((e) => setError(e.message));
-  }, []);
+  }, [token]);
 
   if (error) return <p className="status">{error}</p>;
   if (!card) return <p className="status">Loading...</p>;
@@ -42,6 +43,9 @@ export default function App() {
         <p>
           <span className="label">Expires:</span> {new Date(card.expiresAt).toLocaleDateString()}
         </p>
+      </div>
+      <div className="card-qr">
+        <QRCodeCanvas value={token} size={200} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show QR code with client token on parent portal card
- center QR code styling
- add qrcode.react dependency

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a939b41fdc832ab8e8ec8674bf286c