### PR TITLE
Fix pass lookup for clients with missing revoked field

### DIFF
--- a/services/core-api/src/lib/business.ts
+++ b/services/core-api/src/lib/business.ts
@@ -35,10 +35,10 @@ export async function redeem(
   const passSnap = await db
     .collection('passes')
     .where('clientId', '==', clientRef.id)
-    .where('revoked', '==', false)
     .get();
 
   const passRefs = passSnap.docs
+    .filter(d => (d.data() as any).revoked !== true)
     .sort((a, b) => {
       const aTs = (a.data() as any).purchasedAt?.toMillis?.() || 0;
       const bTs = (b.data() as any).purchasedAt?.toMillis?.() || 0;


### PR DESCRIPTION
## Summary
- handle passes without `revoked` flag when redeeming
- fix client card to show active pass even if `revoked` flag missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a93c9aa694832ab70ceda1850ed348