### PR TITLE
feat: mirror camera display

### DIFF
--- a/web/kiosk-pwa/src/components/CameraScanner.module.css
+++ b/web/kiosk-pwa/src/components/CameraScanner.module.css
@@ -12,6 +12,10 @@
   object-fit: cover;
 }
 
+.mirrored {
+  transform: scaleX(-1);
+}
+
 .scanBox {
   position: absolute;
   inset: 12px;

--- a/web/kiosk-pwa/src/components/CameraScanner.tsx
+++ b/web/kiosk-pwa/src/components/CameraScanner.tsx
@@ -59,7 +59,13 @@ export default function CameraScanner({ onToken }: Props) {
 
   return (
     <div className={styles.cameraWrap}>
-      <video ref={videoRef} playsInline autoPlay muted />
+      <video
+        ref={videoRef}
+        className={facingMode === 'user' ? styles.mirrored : undefined}
+        playsInline
+        autoPlay
+        muted
+      />
       <div className={styles.scanBox} />
       <div className={styles.prompt}>Поднесите QR‑код к камере</div>
       <button type="button" className={styles.switchButton} onClick={toggleCamera}>


### PR DESCRIPTION
## Summary
- mirror camera preview when using front camera for easier QR alignment
- keep scanner functionality unaffected

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a978833664832a88397a8ddbadcf09