### PR TITLE
Add Firestore index for passes queries

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -7,6 +7,16 @@
         { "fieldPath": "fullNameLower", "order": "ASCENDING" },
         { "fieldPath": "active", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "passes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "clientId", "order": "ASCENDING" },
+        { "fieldPath": "revoked", "order": "ASCENDING" },
+        { "fieldPath": "purchasedAt", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
- define composite Firestore index for `passes` collection group to support clientId/revoked/purchasedAt lookups

## Testing
- `npm --prefix web/kiosk-pwa test`

------
https://chatgpt.com/codex/tasks/task_e_68a99db73b98832aa996510299045fba