### PR TITLE
Handle plain QR tokens in kiosk

### DIFF
--- a/web/kiosk-pwa/src/pages/Kiosk.tsx
+++ b/web/kiosk-pwa/src/pages/Kiosk.tsx
@@ -35,8 +35,13 @@ export default function Kiosk() {
     try {
       const payload: { token?: string; clientId?: string } = {};
       const match = data.match(/token=([^&]+)/);
-      if (match) payload.token = decodeURIComponent(match[1]);
-      else payload.clientId = data;
+      if (match) {
+        payload.token = decodeURIComponent(match[1]);
+      } else if (/^[0-9a-f]{32}$/i.test(data)) {
+        payload.token = data;
+      } else {
+        payload.clientId = data;
+      }
       const res = await redeem(payload);
       if (res.status === 'ok') {
         let details: string;


### PR DESCRIPTION
## Summary
- allow kiosk to redeem tokens scanned from parent portal QR codes

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9a8b9a154832ab47a81df3ece2cb9