### PR TITLE
fix: ensure kiosk API URL includes version path

### DIFF
--- a/web/kiosk-pwa/src/lib/api.ts
+++ b/web/kiosk-pwa/src/lib/api.ts
@@ -24,9 +24,12 @@ export type RedeemResponse =
   | RedeemSingleResponse
   | RedeemErrorResponse;
 
-const API_BASE_URL =
-  (import.meta.env.VITE_CORE_API_URL as string | undefined) ??
-  '/api/v1';
+const API_BASE_URL = (() => {
+  const env = import.meta.env.VITE_CORE_API_URL as string | undefined;
+  if (!env) return '/api/v1';
+  const base = env.replace(/\/$/, '');
+  return base.endsWith('/api/v1') ? base : `${base}/api/v1`;
+})();
 
 export async function redeem(data: {
   token?: string;


### PR DESCRIPTION
## Summary
- build core API base URL in kiosk PWA to always include `/api/v1`

## Testing
- `cd web/kiosk-pwa && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa627fb2d0832a91e8e3df942c2321