### PR TITLE
Log kiosk connection errors to interface history

### DIFF
--- a/web/kiosk-pwa/src/pages/Kiosk.tsx
+++ b/web/kiosk-pwa/src/pages/Kiosk.tsx
@@ -66,7 +66,8 @@ export default function Kiosk() {
       console.error(err);
       const msg = 'Ошибка соединения';
       setToast({ kind: 'error', message: msg });
-      pushHistory(msg);
+      const errMsg = err instanceof Error ? err.message : String(err);
+      pushHistory(`${msg}: ${errMsg}`);
       setSuccessInfo(null);
       beep(false);
     } finally {


### PR DESCRIPTION
## Summary
- log connection errors in kiosk interface history for easier debugging

## Testing
- `cd web/kiosk-pwa && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa6c40ae90832a9b57a26b78ec06b7