### PR TITLE
Remove redundant Secret Manager setup in Cloud Build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,25 +17,6 @@ steps:
       - |
         gcloud services enable firestore.googleapis.com
 
-  - id: enable-secretmanager-api
-    name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
-    entrypoint: bash
-    args:
-      - -c
-      - |
-        gcloud services enable secretmanager.googleapis.com
-
-  - id: grant-secret-access
-    name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
-    entrypoint: bash
-    args:
-      - -c
-      - |
-        gcloud secrets add-iam-policy-binding zabicekiosk_firebase_api_key \
-          --project $PROJECT_ID \
-          --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
-          --role="roles/secretmanager.secretAccessor"
-
   - id: build-and-deploy-core-api
     name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     entrypoint: bash


### PR DESCRIPTION
## Summary
- Simplify Cloud Build pipeline by removing secret manager enable and IAM grant steps

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7e2f16d4832a97d937448501b565