### PR TITLE
fix: update Firebase secret path

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -98,7 +98,7 @@ options:
 
 availableSecrets:
   secretManager:
-    - versionName: projects/$PROJECT_ID/secrets/zabicekiosk_firebase_api_key/versions/latest
+    - versionName: projects/120039745928/secrets/zabicekiosk_firebase_api_key/versions/latest
       env: VITE_FIREBASE_API_KEY
 
 substitutions:


### PR DESCRIPTION
## Summary
- fix Cloud Build secret path for Firebase API key to use project number

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa831c7be0832a937bfe595e4e8ed2