### PR TITLE
fix: pin firebase secret version

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -98,7 +98,7 @@ options:
 
 availableSecrets:
   secretManager:
-    - versionName: projects/120039745928/secrets/zabicekiosk_firebase_api_key/versions/latest
+    - versionName: projects/120039745928/secrets/zabicekiosk_firebase_api_key/versions/1
       env: VITE_FIREBASE_API_KEY
 
 substitutions:


### PR DESCRIPTION
## Summary
- use explicit secret version for Firebase API key in Cloud Build config

## Testing
- `npm test` *(fails: could not read package.json)*
- `npm test` (web/parent-web) *(No tests)*


------
https://chatgpt.com/codex/tasks/task_e_68aac3655538832a89ea0db24e36543e