### PR TITLE
fix: specify firebase api key secret version

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -67,7 +67,7 @@ steps:
     args:
       - -c
       - |
-        gcloud secrets versions access latest --secret=zabicekiosk_firebase_api_key > /workspace/firebase_api_key.txt
+        gcloud secrets versions access projects/120039745928/secrets/zabicekiosk_firebase_api_key/versions/1 > /workspace/firebase_api_key.txt
 
   - id: build-zabice-admin-web-build
     name: node:20


### PR DESCRIPTION
## Summary
- pull Firebase API key from a specific secret version instead of latest in Cloud Build

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab22d54dec832a9ecfc9c78fa90b01