### PR TITLE
fix: allow typing in client creation form

### DIFF
--- a/web/admin-portal/src/components/ui/ClientForm.tsx
+++ b/web/admin-portal/src/components/ui/ClientForm.tsx
@@ -21,7 +21,7 @@ export type ClientFormProps = {
 };
 
 export default function ClientForm({
-  initial = {},
+  initial,
   mode,
   onSubmit,
   onCancel,
@@ -29,11 +29,11 @@ export default function ClientForm({
   error = null,
 }: ClientFormProps) {
   const [values, setValues] = useState({
-    parentName: initial.parentName || '',
-    childName: initial.childName || '',
-    phone: initial.phone || '',
-    telegram: initial.telegram || '',
-    instagram: initial.instagram || '',
+    parentName: initial?.parentName || '',
+    childName: initial?.childName || '',
+    phone: initial?.phone || '',
+    telegram: initial?.telegram || '',
+    instagram: initial?.instagram || '',
   });
 
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
@@ -41,11 +41,11 @@ export default function ClientForm({
   // Reset form when initial values change
   useEffect(() => {
     setValues({
-      parentName: initial.parentName || '',
-      childName: initial.childName || '',
-      phone: initial.phone || '',
-      telegram: initial.telegram || '',
-      instagram: initial.instagram || '',
+      parentName: initial?.parentName || '',
+      childName: initial?.childName || '',
+      phone: initial?.phone || '',
+      telegram: initial?.telegram || '',
+      instagram: initial?.instagram || '',
     });
     setValidationErrors({});
   }, [initial]);


### PR DESCRIPTION
## Summary
- fix client form resetting on every render by not recreating default `initial` object
- ensure initial values are loaded with optional chaining

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab3e4334fc832abe49bdbaee5f8052