### PR TITLE
Add client QR code link with copy and download

### DIFF
--- a/web/admin-portal/src/components/ui/ClientForm.module.css
+++ b/web/admin-portal/src/components/ui/ClientForm.module.css
@@ -246,6 +246,59 @@
   box-shadow: none;
 }
 
+/* QR code section */
+.qrSection {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.qrContainer {
+  margin: 0 auto 1rem;
+  width: 200px;
+  height: 200px;
+}
+
+.qrLink {
+  word-break: break-all;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+  color: var(--muted);
+}
+
+.qrActions {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.qrButton {
+  padding: 0.5rem 1rem;
+  border: 2px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius);
+  background: var(--panel);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.qrButton:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.qrButton:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.qrButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* Required field indicator */
 .label:has(+ .input[required])::after {
   content: ' *';

--- a/web/admin-portal/src/pages/Clients.tsx
+++ b/web/admin-portal/src/pages/Clients.tsx
@@ -91,22 +91,30 @@ export default function Clients() {
       key: 'name',
       title: 'Client',
       render: (client: Client) => (
-        <div>
+        <div
+          style={{ cursor: 'pointer' }}
+          onClick={() => {
+            setEditingClient(client);
+            setShowForm(true);
+          }}
+        >
           <div style={{ fontWeight: '600', marginBottom: '0.25rem' }}>
             {client.parentName}
           </div>
-          <div style={{ 
-            fontSize: '0.875rem', 
-            color: 'var(--muted)',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.5rem'
-          }}>
+          <div
+            style={{
+              fontSize: '0.875rem',
+              color: 'var(--muted)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+            }}
+          >
             <span>👶</span>
             {client.childName}
           </div>
         </div>
-      )
+      ),
     },
     {
       key: 'contact',


### PR DESCRIPTION
## Summary
- show QR code for parent portal e-pass when editing a client
- allow copying the e-pass link and downloading the QR image
- open client details form by clicking on the client in the list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab3fa28220832a8c0f7b20a2610dea