### PR TITLE
Mirror front-facing camera in kiosk

### DIFF
--- a/web/kiosk-pwa/src/components/CameraScanner.tsx
+++ b/web/kiosk-pwa/src/components/CameraScanner.tsx
@@ -55,12 +55,12 @@ export default function CameraScanner({ onScan, isOnline }: CameraScannerProps) 
 
   return (
     <div className={styles.cameraWrap}>
-      <video 
-        ref={videoRef} 
-        autoPlay 
-        playsInline 
+      <video
+        ref={videoRef}
+        autoPlay
+        playsInline
         muted
-        className={facingMode === 'user' ? styles.mirrored : ''}
+        style={{ transform: facingMode === 'user' ? 'scaleX(-1)' : 'none' }}
       />
       
       <div className={styles.scanBox} />

--- a/web/kiosk-pwa/src/pages/Kiosk.tsx
+++ b/web/kiosk-pwa/src/pages/Kiosk.tsx
@@ -153,12 +153,12 @@ export default function Kiosk() {
 
       <div className={styles.cameraContainer}>
         <div className={styles.cameraWrap}>
-          <video 
-            ref={videoRef} 
-            autoPlay 
-            playsInline 
+          <video
+            ref={videoRef}
+            autoPlay
+            playsInline
             muted
-            className={facingMode === 'user' ? styles.mirrored : ''}
+            style={{ transform: facingMode === 'user' ? 'scaleX(-1)' : 'none' }}
           />
           
           <div className={styles.scanBox} />


### PR DESCRIPTION
## Summary
- mirror front camera preview in kiosk PWA to ease QR code alignment
- apply same front camera mirroring in CameraScanner component

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab426ded8c832a874ee1670ff6a033