### PR TITLE
feat: prevent multiple drop-ins per day

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -17,6 +17,14 @@
         { "fieldPath": "purchasedAt", "order": "DESCENDING" },
         { "fieldPath": "__name__", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "redeems",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "clientId", "order": "ASCENDING" },
+        { "fieldPath": "ts", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
- block drop-in redeems if client already used a session today
- add Firestore index for querying latest redeems

## Testing
- `cd services/core-api && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab70942b0c832a981d54d727addb7d