### PR TITLE
feat: add backend logic for content, settings, and schedule

### DIFF
--- a/services/booking-api/openapi.yaml
+++ b/services/booking-api/openapi.yaml
@@ -15,3 +15,14 @@ paths:
       responses:
         '200':
           description: OK
+  /v1/admin/schedule:
+    get:
+      summary: Get schedule
+      responses:
+        '200':
+          description: OK
+    put:
+      summary: Update schedule
+      responses:
+        '200':
+          description: OK

--- a/services/booking-api/src/routes/admin.schedule.ts
+++ b/services/booking-api/src/routes/admin.schedule.ts
@@ -1,7 +1,19 @@
 import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { getDb } from '../lib/firestore.js';
 
 export default async function adminSchedule(app: FastifyInstance) {
+  const db = getDb();
+  const scheduleSchema = z.record(z.any());
+
   app.get('/schedule', async () => {
-    return { items: [] };
+    const snap = await db.collection('schedule').doc('global').get();
+    return snap.exists ? snap.data() : {};
+  });
+
+  app.put('/schedule', async req => {
+    const body = scheduleSchema.parse(req.body);
+    await db.collection('schedule').doc('global').set(body, { merge: true });
+    return { status: 'ok' };
   });
 }

--- a/services/core-api/openapi.yaml
+++ b/services/core-api/openapi.yaml
@@ -21,3 +21,43 @@ paths:
       responses:
         '200':
           description: OK
+  /api/v1/content/active:
+    get:
+      summary: Get active promo content
+      responses:
+        '200':
+          description: OK
+  /api/v1/admin/settings:
+    get:
+      summary: Get global settings
+      responses:
+        '200':
+          description: OK
+    put:
+      summary: Update global settings
+      responses:
+        '200':
+          description: OK
+  /api/v1/admin/content:
+    get:
+      summary: List promo content
+      responses:
+        '200':
+          description: OK
+    post:
+      summary: Create promo content item
+      responses:
+        '200':
+          description: OK
+  /api/v1/admin/content/{id}:
+    patch:
+      summary: Update promo content item
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: OK

--- a/services/core-api/src/index.ts
+++ b/services/core-api/src/index.ts
@@ -10,6 +10,7 @@ export async function buildServer() {
 
   await app.register(import('./routes/public.card.js'), { prefix: '/api/v1' });
   await app.register(import('./routes/public.redeem.js'), { prefix: '/api/v1' });
+  await app.register(import('./routes/public.content.js'), { prefix: '/api/v1' });
 
   const adminClients = (await import('./routes/admin.clients.js')).default;
   const adminPasses = (await import('./routes/admin.passes.js')).default;

--- a/services/core-api/src/routes/admin.content.ts
+++ b/services/core-api/src/routes/admin.content.ts
@@ -1,7 +1,74 @@
 import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { getDb } from '../lib/firestore.js';
+import { requireAdmin } from '../lib/auth.js';
+import { FieldValue } from '@google-cloud/firestore';
+
+function serializeContent(id: string, data: any) {
+  return {
+    id,
+    title: data.title,
+    message: data.message,
+    type: data.type,
+    priority: data.priority,
+    active: data.active,
+    targetAudience: data.targetAudience,
+    createdAt: data.createdAt?.toDate?.().toISOString(),
+    updatedAt: data.updatedAt?.toDate?.().toISOString(),
+    expiresAt: data.expiresAt?.toDate?.().toISOString(),
+  };
+}
 
 export default async function adminContent(app: FastifyInstance) {
-  app.get('/pages', async () => {
-    return { items: [] };
+  const db = getDb();
+  const contentSchema = z.object({
+    title: z.string().trim().min(1),
+    message: z.string().trim().optional(),
+    type: z.string().trim().default('info'),
+    priority: z.number().int().default(0),
+    active: z.boolean().default(true),
+    expiresAt: z.coerce.date().optional(),
+    targetAudience: z.string().trim().optional(),
+  });
+
+  app.get('/content', { preHandler: requireAdmin }, async () => {
+    const snap = await db.collection('promoContent').orderBy('priority', 'desc').get();
+    const items = snap.docs.map(d => serializeContent(d.id, d.data()));
+    return { items };
+  });
+
+  app.post('/content', { preHandler: requireAdmin }, async req => {
+    const body = contentSchema.parse(req.body);
+    const now = FieldValue.serverTimestamp();
+    const data: any = {
+      title: body.title,
+      message: body.message,
+      type: body.type,
+      priority: body.priority,
+      active: body.active,
+      targetAudience: body.targetAudience,
+      createdAt: now,
+      updatedAt: now,
+    };
+    if (body.expiresAt) data.expiresAt = body.expiresAt;
+    const ref = await db.collection('promoContent').add(data);
+    const snap = await ref.get();
+    return serializeContent(ref.id, snap.data()!);
+  });
+
+  app.patch<{ Params: { id: string } }>('/content/:id', { preHandler: requireAdmin }, async req => {
+    const { id } = z.object({ id: z.string() }).parse(req.params);
+    const body = contentSchema.partial().parse(req.body);
+    const update: any = { ...body, updatedAt: FieldValue.serverTimestamp() };
+    if (body.expiresAt) update.expiresAt = body.expiresAt;
+    const ref = db.collection('promoContent').doc(id);
+    await ref.set(update, { merge: true });
+    const snap = await ref.get();
+    if (!snap.exists) {
+      const err: any = new Error('Not Found');
+      err.statusCode = 404;
+      throw err;
+    }
+    return serializeContent(id, snap.data()!);
   });
 }

--- a/services/core-api/src/routes/admin.settings.ts
+++ b/services/core-api/src/routes/admin.settings.ts
@@ -1,7 +1,25 @@
 import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { getDb } from '../lib/firestore.js';
+import { requireAdmin } from '../lib/auth.js';
+import { FieldValue } from '@google-cloud/firestore';
 
 export default async function adminSettings(app: FastifyInstance) {
-  app.get('/settings', async () => {
-    return { bookingEnabled: false };
+  const db = getDb();
+  const settingsSchema = z.record(z.any());
+
+  app.get('/settings', { preHandler: requireAdmin }, async () => {
+    const snap = await db.collection('settings').doc('global').get();
+    return snap.exists ? snap.data() : {};
+  });
+
+  app.put('/settings', { preHandler: requireAdmin }, async req => {
+    const body = settingsSchema.parse(req.body);
+    await db
+      .collection('settings')
+      .doc('global')
+      .set({ ...body, updatedAt: FieldValue.serverTimestamp() }, { merge: true });
+    const snap = await db.collection('settings').doc('global').get();
+    return snap.data();
   });
 }

--- a/services/core-api/src/routes/public.content.ts
+++ b/services/core-api/src/routes/public.content.ts
@@ -1,0 +1,28 @@
+import { FastifyInstance } from 'fastify';
+import { getDb } from '../lib/firestore.js';
+
+export default async function publicContent(app: FastifyInstance) {
+  const db = getDb();
+  app.get('/content/active', async () => {
+    const snap = await db.collection('promoContent').where('active', '==', true).get();
+    const now = Date.now();
+    const items = snap.docs
+      .map(d => {
+        const data = d.data();
+        const expires = data.expiresAt?.toDate?.().getTime();
+        if (expires && expires < now) return null;
+        return {
+          id: d.id,
+          title: data.title,
+          message: data.message,
+          type: data.type,
+          priority: data.priority,
+          targetAudience: data.targetAudience,
+          expiresAt: data.expiresAt?.toDate?.().toISOString(),
+        };
+      })
+      .filter(Boolean)
+      .sort((a: any, b: any) => (b.priority || 0) - (a.priority || 0));
+    return { items };
+  });
+}


### PR DESCRIPTION
## Summary
- add Firestore-backed admin settings CRUD
- implement promo content management and public active feed
- store and update schedule via booking API

## Testing
- `cd services/core-api && npm test`
- `cd services/booking-api && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acdbea1e34832a8b33838e12063413