### PR TITLE
fix: sanitize instagram URLs

### DIFF
--- a/services/core-api/src/routes/admin.clients.ts
+++ b/services/core-api/src/routes/admin.clients.ts
@@ -56,7 +56,13 @@ export default async function adminClients(app: FastifyInstance) {
         if (!/^https?:\/\//.test(url)) {
           url = `https://instagram.com/${url}`;
         }
-        return url;
+        const u = new URL(url);
+        u.search = '';
+        u.hash = '';
+        if (u.pathname.endsWith('/')) {
+          u.pathname = u.pathname.slice(0, -1);
+        }
+        return u.toString();
       })
       .refine(v => !v || /^https?:\/\/([^/]*\.)?instagram\.com\/[A-Za-z0-9._]+\/?$/.test(v), {
         message: 'invalid instagram url',

--- a/web/admin-portal/src/components/ui/ClientForm.tsx
+++ b/web/admin-portal/src/components/ui/ClientForm.tsx
@@ -409,8 +409,13 @@ export default function ClientForm({
         }
         return '';
       case 'instagram':
-        if (value && !/^@?[A-Za-z0-9._]{1,30}$/.test(value.replace(/^https?:\/\/(www\.)?instagram\.com\//, ''))) {
-          return 'Invalid instagram handle';
+        if (value) {
+          const handle = value
+            .replace(/^https?:\/\/(www\.)?instagram\.com\//, '')
+            .replace(/[\/?].*$/, '');
+          if (!/^@?[A-Za-z0-9._]{1,30}$/.test(handle)) {
+            return 'Invalid instagram handle';
+          }
         }
         return '';
       default:
@@ -457,7 +462,11 @@ export default function ClientForm({
       childName: values.childName.trim(),
       phone: values.phone.trim() || undefined,
       telegram: values.telegram.trim().replace(/^@/, '') || undefined,
-      instagram: values.instagram.trim().replace(/^@/, '').replace(/^https?:\/\/(www\.)?instagram\.com\//, '') || undefined,
+      instagram: values.instagram
+        .trim()
+        .replace(/^@/, '')
+        .replace(/^https?:\/\/(www\.)?instagram\.com\//, '')
+        .replace(/[\/?].*$/, '') || undefined,
     };
 
     onSubmit(cleanValues);


### PR DESCRIPTION
## Summary
- sanitize Instagram URLs by stripping query strings and hashes before validation
- trim Instagram handles in client form to remove queries/trailing segments

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2424bd20c832a83146688c2f006d9