### PR TITLE
feat: enable pass sales and tracking

### DIFF
--- a/services/core-api/openapi.yaml
+++ b/services/core-api/openapi.yaml
@@ -21,6 +21,24 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  childName:
+                    type: string
+                  planSize:
+                    type: integer
+                  used:
+                    type: integer
+                  remaining:
+                    type: integer
+                  expiresAt:
+                    type: string
+                    format: date-time
   /api/v1/content/active:
     get:
       summary: Get active promo content

--- a/services/core-api/src/routes/public.card.ts
+++ b/services/core-api/src/routes/public.card.ts
@@ -55,7 +55,8 @@ export default async function publicCard(app: FastifyInstance) {
     }
 
     return {
-      name: client?.childName || client?.parentName || '',
+      name: client?.parentName || client?.childName || '',
+      childName: client?.childName || '',
       planSize,
       used,
       remaining,

--- a/web/admin-portal/src/components/ui/ClientForm.module.css
+++ b/web/admin-portal/src/components/ui/ClientForm.module.css
@@ -809,6 +809,50 @@
   opacity: 0.8;
 }
 
+.addPassForm {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+  align-items: center;
+}
+
+.passSelect {
+  background: var(--panel);
+  color: var(--text);
+  border: 2px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius);
+  padding: 0.75rem 1rem;
+  font-family: var(--font);
+  font-size: 0.875rem;
+  transition: all 0.3s ease;
+}
+
+.passSelect:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(43, 224, 144, 0.1);
+}
+
+.btnSellPass {
+  background: linear-gradient(135deg, var(--accent-2), var(--accent));
+  color: var(--text);
+  border: none;
+  border-radius: var(--radius);
+  padding: 0.75rem 1.5rem;
+  font-family: var(--font);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.btnSellPass:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(74, 214, 255, 0.4);
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
   .qrContainer {
@@ -877,6 +921,16 @@
   }
   
   .passProgress {
+    width: 100%;
+  }
+
+  .addPassForm {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .passSelect,
+  .btnSellPass {
     width: 100%;
   }
 }

--- a/web/admin-portal/src/pages/Passes.tsx
+++ b/web/admin-portal/src/pages/Passes.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { listPasses, deletePass } from '../lib/api';
+import { listPasses, deletePass, createPass } from '../lib/api';
 import { PassWithClient } from '../types';
 import DataTable from '../components/ui/DataTable';
 
@@ -42,6 +42,30 @@ export default function Passes() {
       await loadPasses();
     } catch (err: any) {
       setError(err.message || 'Failed to revoke pass');
+      console.error(err);
+    }
+  };
+
+  const handleSellPass = async () => {
+    const clientId = prompt('Enter client ID');
+    if (!clientId) return;
+    const planSizeStr = prompt('Enter plan size (e.g., 5, 10, 20)');
+    if (!planSizeStr) return;
+    const planSize = parseInt(planSizeStr, 10);
+    if (isNaN(planSize) || planSize <= 0) {
+      alert('Invalid plan size');
+      return;
+    }
+    try {
+      await createPass({
+        clientId,
+        planSize,
+        purchasedAt: new Date().toISOString(),
+        priceRSD: planSize * 1500,
+      });
+      await loadPasses();
+    } catch (err: any) {
+      setError(err.message || 'Failed to sell pass');
       console.error(err);
     }
   };
@@ -201,14 +225,14 @@ export default function Passes() {
 
   return (
     <div>
-      <div style={{ 
-        display: 'flex', 
-        justifyContent: 'space-between', 
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
         alignItems: 'center',
         marginBottom: '2rem'
       }}>
-        <h1 style={{ 
-          fontSize: '2rem', 
+        <h1 style={{
+          fontSize: '2rem',
           fontWeight: '700',
           background: 'linear-gradient(135deg, var(--accent), var(--accent-2))',
           WebkitBackgroundClip: 'text',
@@ -217,6 +241,24 @@ export default function Passes() {
         }}>
           Passes
         </h1>
+        <button
+          onClick={handleSellPass}
+          style={{
+            background: 'linear-gradient(135deg, var(--accent), var(--accent-2))',
+            color: 'var(--text)',
+            border: 'none',
+            borderRadius: 'var(--radius)',
+            padding: '0.75rem 1.5rem',
+            fontFamily: 'var(--font)',
+            fontSize: '0.875rem',
+            fontWeight: '600',
+            cursor: 'pointer',
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px'
+          }}
+        >
+          Sell Pass
+        </button>
       </div>
 
       <div className="toolbar">

--- a/web/admin-portal/src/pages/Redeems.tsx
+++ b/web/admin-portal/src/pages/Redeems.tsx
@@ -54,6 +54,7 @@ export default function Redeems() {
     switch (kind) {
       case 'pass': return '🎫';
       case 'dropin': return '💰';
+      case 'purchase': return '🛒';
       default: return '📋';
     }
   };
@@ -62,6 +63,7 @@ export default function Redeems() {
     switch (kind) {
       case 'pass': return 'var(--accent)';
       case 'dropin': return 'var(--warn)';
+      case 'purchase': return 'var(--accent-2)';
       default: return 'var(--muted)';
     }
   };
@@ -192,6 +194,7 @@ export default function Redeems() {
           <option value="all">All Types</option>
           <option value="pass">Pass Redeems</option>
           <option value="dropin">Drop-in Payments</option>
+          <option value="purchase">Pass Purchases</option>
         </select>
       </div>
 

--- a/web/parent-web/src/App.tsx
+++ b/web/parent-web/src/App.tsx
@@ -94,7 +94,7 @@ export default function App() {
         // Transform API response to match our PassData interface
         const transformedData: PassData = {
           name: data.name || 'Unknown Client',
-          childName: data.childName || data.name || 'Unknown Child',
+          childName: data.childName || 'Unknown Child',
           planSize: data.planSize || 1,
           used: data.used || 0,
           remaining: data.remaining || 0,


### PR DESCRIPTION
## Summary
- allow admins to sell passes from passes list and client form
- record pass purchases in redeems log and revenue stats
- support purchase entries on redeems page and mock API
- persist admin settings via API so changes survive reload
- fix parent portal QR URL to point at zabice-parent-web.web.app
- show parent and child names separately on parent portal pass card

## Testing
- `cd services/core-api && npm test`
- `cd web/parent-web && npm test`
- `cd web/admin-portal && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b2481a6f10832a87238b624dddea7b