### PR TITLE
Use business settings for ticket contact info

### DIFF
--- a/web/admin-portal/src/components/ui/ClientForm.tsx
+++ b/web/admin-portal/src/components/ui/ClientForm.tsx
@@ -1,6 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
 import QRCodeStyling from 'qr-code-styling';
-import { getClientToken, listPasses, createPass } from '../../lib/api';
+import {
+  getClientToken,
+  listPasses,
+  createPass,
+  fetchSettings,
+  type SettingsResponse,
+} from '../../lib/api';
 import styles from './ClientForm.module.css';
 import type { PassWithClient } from '../../types';
 
@@ -48,6 +54,13 @@ export default function ClientForm({
   const qrRef = useRef<HTMLDivElement>(null);
   const qrInstance = useRef<QRCodeStyling | null>(null);
   const ticketCanvasRef = useRef<HTMLCanvasElement>(null);
+  const [settings, setSettings] = useState<SettingsResponse>({});
+
+  useEffect(() => {
+    fetchSettings()
+      .then(setSettings)
+      .catch(err => console.error('Failed to load settings:', err));
+  }, []);
 
   // Reset form when initial values change
   useEffect(() => {
@@ -78,7 +91,7 @@ export default function ClientForm({
         generateTicketCard(passUrl, values.parentName, values.childName);
       }, 100);
     }
-  }, [passUrl, values.parentName, values.childName, mode]);
+  }, [passUrl, values.parentName, values.childName, mode, settings]);
 
   const loadClientPasses = async (clientId: string) => {
     try {
@@ -195,8 +208,8 @@ export default function ClientForm({
     // Business name
     ctx.fillStyle = '#0F1115';
     ctx.font = 'bold 28px Inter, sans-serif';
-    ctx.fillText('Swimming Academy', 100, 45);
-    
+    ctx.fillText(settings.businessName || 'Swimming Academy', 100, 45);
+
     ctx.font = '18px Inter, sans-serif';
     ctx.fillText('Professional Swimming Lessons', 100, 70);
 
@@ -225,10 +238,27 @@ export default function ClientForm({
     // Business information
     ctx.fillStyle = '#9AA5B1';
     ctx.font = '16px Inter, sans-serif';
-    ctx.fillText('📍 Belgrade, Serbia', 40, 310);
-    ctx.fillText('📞 +381 60 123 4567', 40, 335);
-    ctx.fillText('📧 info@swimming-academy.rs', 40, 360);
-    ctx.fillText('💬 @Tretiakovaanny', 40, 385);
+    let infoY = 310;
+    const lineHeight = 25;
+    if (settings.businessAddress) {
+      ctx.fillText(`📍 ${settings.businessAddress}`, 40, infoY);
+      infoY += lineHeight;
+    }
+    if (settings.businessPhone) {
+      ctx.fillText(`📞 ${settings.businessPhone}`, 40, infoY);
+      infoY += lineHeight;
+    }
+    if (settings.businessEmail) {
+      ctx.fillText(`📧 ${settings.businessEmail}`, 40, infoY);
+      infoY += lineHeight;
+    }
+    if (settings.businessTelegram) {
+      ctx.fillText(`💬 ${settings.businessTelegram}`, 40, infoY);
+      infoY += lineHeight;
+    }
+    if (settings.businessInstagram) {
+      ctx.fillText(`📸 ${settings.businessInstagram}`, 40, infoY);
+    }
 
     // Instructions
     ctx.fillStyle = '#EAEFF5';

--- a/web/admin-portal/src/lib/api.ts
+++ b/web/admin-portal/src/lib/api.ts
@@ -435,6 +435,8 @@ export interface SettingsResponse {
   businessAddress?: string;
   businessPhone?: string;
   businessEmail?: string;
+  businessTelegram?: string;
+  businessInstagram?: string;
   [key: string]: any;
 }
 

--- a/web/admin-portal/src/pages/Settings.tsx
+++ b/web/admin-portal/src/pages/Settings.tsx
@@ -23,6 +23,8 @@ interface GeneralSettings {
   businessAddress: string;
   businessPhone: string;
   businessEmail: string;
+  businessTelegram: string;
+  businessInstagram: string;
 }
 
 export default function Settings() {
@@ -49,7 +51,9 @@ export default function Settings() {
     businessName: 'Swimming Academy',
     businessAddress: 'Belgrade, Serbia',
     businessPhone: '+381 60 123 4567',
-    businessEmail: 'info@swimming-academy.rs'
+    businessEmail: 'info@swimming-academy.rs',
+    businessTelegram: '@Tretiakovaanny',
+    businessInstagram: '@swimmingacademy'
   });
 
   useEffect(() => {
@@ -72,6 +76,8 @@ export default function Settings() {
         businessAddress: settings.businessAddress ?? '',
         businessPhone: settings.businessPhone ?? '',
         businessEmail: settings.businessEmail ?? '',
+        businessTelegram: settings.businessTelegram ?? '',
+        businessInstagram: settings.businessInstagram ?? '',
       });
       setLoading(false);
     } catch (err: any) {
@@ -103,6 +109,8 @@ export default function Settings() {
         businessAddress: saved.businessAddress ?? generalSettings.businessAddress,
         businessPhone: saved.businessPhone ?? generalSettings.businessPhone,
         businessEmail: saved.businessEmail ?? generalSettings.businessEmail,
+        businessTelegram: saved.businessTelegram ?? generalSettings.businessTelegram,
+        businessInstagram: saved.businessInstagram ?? generalSettings.businessInstagram,
       });
 
       setSuccess('Settings saved successfully!');
@@ -421,6 +429,34 @@ export default function Settings() {
                   }))}
                   className={styles.input}
                   placeholder="info@business.com"
+                />
+              </div>
+
+              <div className={styles.formGroup}>
+                <label className={styles.label}>Telegram</label>
+                <input
+                  type="text"
+                  value={generalSettings.businessTelegram}
+                  onChange={(e) => setGeneralSettings(prev => ({
+                    ...prev,
+                    businessTelegram: e.target.value
+                  }))}
+                  className={styles.input}
+                  placeholder="@username"
+                />
+              </div>
+
+              <div className={styles.formGroup}>
+                <label className={styles.label}>Instagram</label>
+                <input
+                  type="text"
+                  value={generalSettings.businessInstagram}
+                  onChange={(e) => setGeneralSettings(prev => ({
+                    ...prev,
+                    businessInstagram: e.target.value
+                  }))}
+                  className={styles.input}
+                  placeholder="@username"
                 />
               </div>
 


### PR DESCRIPTION
## Summary
- Load business settings in ClientForm and render contact details on printed ticket
- Extend settings with Telegram and Instagram fields and expose in admin UI
- Update API types to include new social fields

## Testing
- ⚠️ `npm test` (Missing script: "test")
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2558596ac832a8c6aca6975a00b92