### PR TITLE
feat: sell passes using settings options

### DIFF
--- a/services/core-api/src/routes/admin.passes.ts
+++ b/services/core-api/src/routes/admin.passes.ts
@@ -81,6 +81,7 @@ export default async function adminPasses(app: FastifyInstance) {
       planSize: z.coerce.number().min(1),
       purchasedAt: z.string().datetime(),
       priceRSD: z.coerce.number().optional(),
+      validityDays: z.coerce.number().min(1).max(365).optional(),
     });
     const body = bodySchema.parse(req.body);
 
@@ -97,7 +98,10 @@ export default async function adminPasses(app: FastifyInstance) {
 
     const purchasedAt = Timestamp.fromDate(new Date(body.purchasedAt));
     const expiresAt = Timestamp.fromDate(
-      new Date(purchasedAt.toDate().getTime() + 30 * 24 * 60 * 60 * 1000)
+      new Date(
+        purchasedAt.toDate().getTime() +
+          (body.validityDays ?? 30) * 24 * 60 * 60 * 1000,
+      )
     );
 
     await db.runTransaction(async tx => {

--- a/web/admin-portal/src/lib/api.ts
+++ b/web/admin-portal/src/lib/api.ts
@@ -197,6 +197,7 @@ export async function createPass(body: {
   planSize: number;
   purchasedAt: string;
   priceRSD?: number;
+  validityDays?: number;
 }): Promise<void> {
   // Use mock data in development mode
   if (import.meta.env.DEV) {

--- a/web/admin-portal/src/pages/Passes.tsx
+++ b/web/admin-portal/src/pages/Passes.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { listPasses, deletePass, createPass } from '../lib/api';
+import { listPasses, deletePass } from '../lib/api';
 import { PassWithClient } from '../types';
 import DataTable from '../components/ui/DataTable';
 import SellPassForm from '../components/ui/SellPassForm';


### PR DESCRIPTION
## Summary
- load pass type options from settings when selling a pass
- allow specifying pass validity when creating passes
- compute pass expiration from configured validity days

## Testing
- `npm test` *(services/core-api)*
- `npm test` *(web/admin-portal) (fails: Missing script "test")*
- `npm run lint` *(web/admin-portal)*

------
https://chatgpt.com/codex/tasks/task_e_68b25f60c650832a8d9a9ff244910734