### PR TITLE
Check existing pass before selling new one

### DIFF
--- a/web/admin-portal/src/components/ui/SellPassForm.tsx
+++ b/web/admin-portal/src/components/ui/SellPassForm.tsx
@@ -210,17 +210,21 @@ export default function SellPassForm({ open, onClose, onSuccess, preselectedClie
     try {
       setSubmitting(true);
       setError(null);
-      
-      await createPass({
+
+      const res = await createPass({
         clientId: selectedClient.id,
         planSize: passConfig.sessions,
         purchasedAt: new Date().toISOString(),
         priceRSD: passConfig.priceRSD,
         validityDays: passConfig.validityDays,
       });
-      
-      onSuccess();
-      onClose();
+
+      if (res.status === 'exists') {
+        setError('Client already has an active pass');
+      } else {
+        onSuccess();
+        onClose();
+      }
     } catch (err: any) {
       setError(err.message || 'Failed to create pass');
     } finally {


### PR DESCRIPTION
## Summary
- Respect API's `exists` status when creating passes
- Prevent selling new pass if client already has active one

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2682d77e0832a9ca436ca16dbc34c