### PR TITLE
feat: implement kiosk settings endpoints

### DIFF
--- a/services/core-api/src/index.ts
+++ b/services/core-api/src/index.ts
@@ -22,6 +22,7 @@ export async function buildServer() {
   const adminContent = (await import('./routes/admin.content.js')).default;
   const adminUsers = (await import('./routes/admin.users.js')).default;
   const adminStats = (await import('./routes/admin.stats.js')).default;
+  const adminKiosks = (await import('./routes/admin.kiosks.js')).default;
 
   await app.register(adminClients, { prefix: '/api/v1/admin' });
 
@@ -36,6 +37,8 @@ export async function buildServer() {
   await app.register(adminUsers, { prefix: '/api/v1/admin' });
 
   await app.register(adminStats, { prefix: '/api/v1/admin' });
+
+  await app.register(adminKiosks, { prefix: '/api/v1/admin' });
 
   return app;
 }

--- a/services/core-api/src/routes/admin.kiosks.ts
+++ b/services/core-api/src/routes/admin.kiosks.ts
@@ -1,0 +1,104 @@
+import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { getDb } from '../lib/firestore.js';
+import { requireAdmin } from '../lib/auth.js';
+import { FieldValue } from '@google-cloud/firestore';
+
+export default async function adminKiosks(app: FastifyInstance) {
+  const db = getDb();
+
+  const settingsRef = db.collection('settings').doc('kiosk');
+
+  const settingsSchema = z.object({
+    adminPin: z.string().regex(/^\d{4}$/),
+    maxIdleMinutes: z.number().int().min(1).max(120),
+    autoLogoutEnabled: z.boolean(),
+    soundEnabled: z.boolean(),
+    cameraFacingMode: z.enum(['user', 'environment']),
+    scanCooldownSec: z.number().int().min(0).max(60),
+  });
+
+  const configureSchema = z.object({
+    kioskId: z.string(),
+    adminPin: z.string().regex(/^\d{4}$/),
+    location: z.string().trim().min(1),
+    description: z.string().trim().optional(),
+    scannerPosition: z.enum(['left', 'right', 'top']),
+    soundEnabled: z.boolean(),
+    cameraFacingMode: z.enum(['user', 'environment']),
+    scanCooldownSec: z.number().int().min(0).max(60),
+    maxIdleMinutes: z.number().int().min(1).max(120),
+  });
+
+  function generatePin(): string {
+    return Math.floor(1000 + Math.random() * 9000).toString();
+  }
+
+  app.get('/kiosks/settings', { preHandler: requireAdmin }, async () => {
+    const snap = await settingsRef.get();
+    let settings: any;
+    if (snap.exists) {
+      settings = snap.data();
+    } else {
+      settings = {
+        adminPin: generatePin(),
+        maxIdleMinutes: 30,
+        autoLogoutEnabled: true,
+        soundEnabled: true,
+        cameraFacingMode: 'environment',
+        scanCooldownSec: 2,
+      };
+      await settingsRef.set(settings);
+    }
+
+    const kiosksSnap = await db.collection('kiosks').get();
+    const kiosks = kiosksSnap.docs.map(d => {
+      const data = d.data();
+      return {
+        id: d.id,
+        registeredAt: data.registeredAt?.toDate().toISOString(),
+        lastSeen: data.lastSeen?.toDate().toISOString(),
+        version: data.version,
+        location: data.location,
+        description: data.description,
+      };
+    });
+
+    return { settings, kiosks };
+  });
+
+  app.put('/kiosks/settings', { preHandler: requireAdmin }, async req => {
+    const body = settingsSchema.parse(req.body);
+    await settingsRef.set({ ...body, updatedAt: FieldValue.serverTimestamp() }, { merge: true });
+    const snap = await settingsRef.get();
+    return snap.data();
+  });
+
+  app.post('/kiosks/verify-pin', async (req, reply) => {
+    const { pin } = z.object({ pin: z.string() }).parse(req.body);
+    const snap = await settingsRef.get();
+    const data = snap.data();
+    if (data?.adminPin === pin) {
+      return { status: 'ok' };
+    }
+    reply.code(400);
+    return { message: 'Invalid PIN' };
+  });
+
+  app.post('/kiosks/configure', async (req, reply) => {
+    const body = configureSchema.parse(req.body);
+    const snap = await settingsRef.get();
+    const data = snap.data();
+    if (data?.adminPin !== body.adminPin) {
+      reply.code(400);
+      return { message: 'Invalid PIN' };
+    }
+    const { kioskId, adminPin, ...config } = body;
+    await db
+      .collection('kiosks')
+      .doc(kioskId)
+      .set({ ...config, configuredAt: FieldValue.serverTimestamp() }, { merge: true });
+    return { status: 'ok' };
+  });
+}
+

--- a/services/core-api/src/routes/public.kiosk.ts
+++ b/services/core-api/src/routes/public.kiosk.ts
@@ -6,10 +6,22 @@ import { FieldValue } from '@google-cloud/firestore';
 export default async function publicKiosk(app: FastifyInstance) {
   const db = getDb();
   app.post('/kiosks/register', async req => {
-    const { kioskId } = z.object({ kioskId: z.string() }).parse(req.body);
-    const ref = db.collection('kiosks').doc(kioskId);
+    const body = z
+      .object({
+        kioskId: z.string(),
+        location: z.string().optional(),
+        description: z.string().optional(),
+        version: z.string().optional(),
+      })
+      .parse(req.body);
+
+    const ref = db.collection('kiosks').doc(body.kioskId);
     const now = FieldValue.serverTimestamp();
-    await ref.set({ registeredAt: now, lastSeen: now }, { merge: true });
+    const data: any = { registeredAt: now, lastSeen: now };
+    if (body.location) data.location = body.location;
+    if (body.description) data.description = body.description;
+    if (body.version) data.version = body.version;
+    await ref.set(data, { merge: true });
     return { status: 'ok' };
   });
 }


### PR DESCRIPTION
## Summary
- extend kiosk registration to store device metadata
- add admin kiosk settings API with pin verification and configuration endpoints
- register kiosk management routes on the server

## Testing
- `npm test --prefix services/core-api`

------
https://chatgpt.com/codex/tasks/task_e_68b2a26bbe90832a92a06fb727f05242