### PR TITLE
fix: enable popup google login on ios

### DIFF
--- a/web/admin-portal/src/lib/auth.ts
+++ b/web/admin-portal/src/lib/auth.ts
@@ -26,15 +26,14 @@ export async function loginWithGoogle() {
   }
   
   try {
-    // iOS часто блокирует popup — сразу уходим в redirect
-    if (/iPad|iPhone|iPod/i.test(navigator.userAgent)) {
-      await signInWithRedirect(auth, provider);
-      return null;
-    }
     const res = await signInWithPopup(auth, provider);
     return res.user;
-  } catch (e:any) {
-    if (e?.code === 'auth/popup-blocked' || e?.code === 'auth/cancelled-popup-request') {
+  } catch (e: any) {
+    if (
+      e?.code === 'auth/popup-blocked' ||
+      e?.code === 'auth/cancelled-popup-request' ||
+      e?.code === 'auth/operation-not-supported-in-this-environment'
+    ) {
       await signInWithRedirect(auth, provider);
       return null;
     }


### PR DESCRIPTION
## Summary
- ensure Google login uses popup by default
- fallback to redirect only if popup/operation unsupported

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2ac55738c832aa468475a1e0a61c6