### PR TITLE
fix: improve client search on pass sale

### DIFF
--- a/web/admin-portal/src/components/ui/SellPassForm.tsx
+++ b/web/admin-portal/src/components/ui/SellPassForm.tsx
@@ -89,8 +89,9 @@ export default function SellPassForm({ open, onClose, onSuccess, preselectedClie
   };
 
   useEffect(() => {
-    if (searchTerm.length >= 2) {
-      searchClients();
+    const term = searchTerm.trim();
+    if (term.length >= 2) {
+      searchClients(term);
     } else {
       setClients([]);
       setShowDropdown(false);
@@ -137,11 +138,11 @@ export default function SellPassForm({ open, onClose, onSuccess, preselectedClie
     }
   };
 
-  const searchClients = async () => {
+  const searchClients = async (term: string) => {
     try {
       setLoadingClients(true);
       const data = await listClients({
-        search: searchTerm,
+        search: term,
         active: 'true',
         pageSize: 10,
       });
@@ -150,6 +151,7 @@ export default function SellPassForm({ open, onClose, onSuccess, preselectedClie
     } catch (err) {
       console.error('Failed to search clients:', err);
       setClients([]);
+      setShowDropdown(true);
     } finally {
       setLoadingClients(false);
     }

--- a/web/admin-portal/src/lib/mockData.ts
+++ b/web/admin-portal/src/lib/mockData.ts
@@ -373,10 +373,15 @@ export function filterClients(
 
   // Apply search filter
   if (filters.search) {
-    const searchLower = filters.search.toLowerCase();
+    const normalize = (s: string) =>
+      s
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase();
+    const searchLower = normalize(filters.search);
     filtered = filtered.filter(client =>
-      client.parentName.toLowerCase().includes(searchLower) ||
-      client.childName.toLowerCase().includes(searchLower)
+      normalize(client.parentName).includes(searchLower) ||
+      normalize(client.childName).includes(searchLower)
     );
   }
 


### PR DESCRIPTION
## Summary
- trim search input and surface dropdown even when search fails
- normalize client names for diacritic-insensitive matching in dev data

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2b940e21c832a8ce0522ad494d36e