### PR TITLE
feat(admin): refresh kiosk status in management dialog

### DIFF
--- a/web/admin-portal/src/components/ui/KioskRegistration.module.css
+++ b/web/admin-portal/src/components/ui/KioskRegistration.module.css
@@ -292,6 +292,13 @@
   background: rgba(255, 209, 102, 0.1);
 }
 
+.kioskSummary {
+  text-align: right;
+  font-size: 0.875rem;
+  color: var(--muted);
+  margin: 0.5rem 0 1rem;
+}
+
 .kiosksList {
   display: flex;
   flex-direction: column;

--- a/web/admin-portal/src/components/ui/KioskRegistration.tsx
+++ b/web/admin-portal/src/components/ui/KioskRegistration.tsx
@@ -49,6 +49,14 @@ export default function KioskRegistration({ open, onClose, onSaved }: KioskRegis
     }
   }, [open]);
 
+  useEffect(() => {
+    if (!open) return;
+    const id = setInterval(() => {
+      loadKioskSettings();
+    }, 30000);
+    return () => clearInterval(id);
+  }, [open]);
+
   const loadKioskSettings = async () => {
     try {
       setLoading(true);
@@ -189,6 +197,8 @@ export default function KioskRegistration({ open, onClose, onSaved }: KioskRegis
     const diffInMinutes = (now.getTime() - lastSeenDate.getTime()) / (1000 * 60);
     return diffInMinutes < 5 ? 'online' : 'offline';
   };
+
+  const onlineCount = registeredKiosks.filter(k => getKioskStatus(k.lastSeen) === 'online').length;
 
   if (!open) return null;
 
@@ -401,6 +411,10 @@ export default function KioskRegistration({ open, onClose, onSaved }: KioskRegis
                 </h3>
                 <p className={styles.sectionDescription}>
                   Devices that have connected to the system
+                </p>
+
+                <p className={styles.kioskSummary}>
+                  {onlineCount} of {registeredKiosks.length} kiosks online
                 </p>
 
                 {registeredKiosks.length > 0 ? (


### PR DESCRIPTION
## Summary
- auto refresh kiosk data every 30s while dialog open
- show how many kiosks are online out of total
- style summary element

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2c5131ec0832aae043711edf31698