### PR TITLE
Fix client pass search and preselection

### DIFF
--- a/web/admin-portal/src/components/ui/ClientForm.tsx
+++ b/web/admin-portal/src/components/ui/ClientForm.tsx
@@ -8,7 +8,7 @@ import {
   type SettingsResponse,
 } from '../../lib/api';
 import styles from './ClientForm.module.css';
-import type { PassWithClient } from '../../types';
+import type { PassWithClient, Client as ApiClient } from '../../types';
 
 export type Client = {
   id: string;
@@ -858,7 +858,7 @@ export default function ClientForm({
             open={showSellPassForm}
             onClose={() => setShowSellPassForm(false)}
             onSuccess={handleSellPassSuccess}
-            preselectedClientId={initial.id as string}
+            preselectedClient={initial as ApiClient}
           />
         )}
       </div>

--- a/web/admin-portal/src/pages/Passes.tsx
+++ b/web/admin-portal/src/pages/Passes.tsx
@@ -53,13 +53,18 @@ export default function Passes() {
     setError(null);
   };
 
+  const normalize = (s: string) =>
+    s
+      .normalize('NFD')
+      .replace(/\p{Diacritic}/gu, '')
+      .toLowerCase();
+
   const filteredPasses = passes.filter(pass => {
     if (!searchTerm) return true;
-    const searchLower = searchTerm.toLowerCase();
-    return (
-      pass.client.parentName.toLowerCase().includes(searchLower) ||
-      pass.client.childName.toLowerCase().includes(searchLower)
-    );
+    const searchLower = normalize(searchTerm);
+    const parent = normalize(pass.client?.parentName || '');
+    const child = normalize(pass.client?.childName || '');
+    return parent.includes(searchLower) || child.includes(searchLower);
   });
 
   const formatDate = (dateString?: string) => {


### PR DESCRIPTION
## Summary
- Improve Sell Pass form search to match parent or child names using local filtering
- Allow passing full client object to preselect active client in Sell Pass form
- Normalize pass listing search for parent and child names

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2f9b37ba8832a97113f529494caef