### PR TITLE
feat: remove pass on revoke

### DIFF
--- a/services/core-api/src/routes/admin.passes.ts
+++ b/services/core-api/src/routes/admin.passes.ts
@@ -143,10 +143,7 @@ export default async function adminPasses(app: FastifyInstance) {
       }
       const pass = passSnap.data() as any;
       await db.runTransaction(async tx => {
-        tx.update(passRef, {
-          revoked: true,
-          revokedAt: FieldValue.serverTimestamp(),
-        });
+        tx.delete(passRef);
         const revRef = db.collection('redeems').doc();
         tx.set(revRef, {
           ts: FieldValue.serverTimestamp(),


### PR DESCRIPTION
## Summary
- delete pass documents when revoking a pass
- record revoke action in redeems log

## Testing
- `cd services/core-api && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3b0bd2808832a9e060f9f83b7e100