### PR TITLE
fix: add redeems index

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -23,7 +23,8 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "clientId", "order": "ASCENDING" },
-        { "fieldPath": "ts", "order": "DESCENDING" }
+        { "fieldPath": "ts", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "ASCENDING" }
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- include document name in redeems Firestore index so kiosk scan query succeeds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b61226ed8c832a87fe7892654dcdcf