### PR TITLE
feat: show details in success overlay

### DIFF
--- a/web/kiosk-pwa/src/components/SuccessOverlay.module.css
+++ b/web/kiosk-pwa/src/components/SuccessOverlay.module.css
@@ -97,7 +97,8 @@
   }
 }
 
-.successDetails {
+
+.successMessage {
   font-size: 1.5rem;
   color: rgba(255, 255, 255, 0.9);
   text-align: center;
@@ -105,6 +106,16 @@
   font-weight: 600;
   animation: detailsSlideUp 0.6s ease-out 1.4s both;
   text-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.successDetails {
+  font-size: 1.25rem;
+  color: rgba(255, 255, 255, 0.9);
+  text-align: center;
+  margin: 0.5rem 0 0 0;
+  font-weight: 500;
+  animation: detailsSlideUp 0.6s ease-out 1.6s both;
+  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.1);
 }
 
 @keyframes detailsSlideUp {

--- a/web/kiosk-pwa/src/components/SuccessOverlay.tsx
+++ b/web/kiosk-pwa/src/components/SuccessOverlay.tsx
@@ -4,11 +4,12 @@ import styles from './SuccessOverlay.module.css';
 interface SuccessOverlayProps {
   isVisible: boolean;
   message: string;
-  details: string;
+  details?: string;
   remaining?: number;
   planSize?: number;
   expiresAt?: string;
-}
+  }
+
 
 export default function SuccessOverlay({ 
   isVisible, 
@@ -30,7 +31,7 @@ export default function SuccessOverlay({
   };
 
   return (
-    <div className={styles.overlay} tabIndex={0} role="dialog" aria-label="Успешное сканирование">
+  <div className={styles.overlay} tabIndex={0} role="dialog" aria-label="Успешное сканирование">
       {/* Floating particles */}
       <div className={styles.particles}>
         <div className={styles.particle}></div>
@@ -58,9 +59,15 @@ export default function SuccessOverlay({
         УСПЕШНАЯ ОПЛАТА
       </h1>
 
-      <p className={styles.successDetails}>
+      <p className={styles.successMessage}>
         {message}
       </p>
+
+      {details && (
+        <p className={styles.successDetails}>
+          {details}
+        </p>
+      )}
 
       {/* Pass information */}
       {(remaining !== undefined && planSize !== undefined) && (

--- a/web/kiosk-pwa/src/pages/Kiosk.tsx
+++ b/web/kiosk-pwa/src/pages/Kiosk.tsx
@@ -280,9 +280,7 @@ export default function Kiosk() {
         setTimeout(() => setFlashEffect(null), 800);
 
         const isPass = result.type === 'pass';
-        const message = isPass
-          ? 'Pass redeemed successfully!'
-          : result.message;
+        const message = result.message;
         const details = isPass
           ? `${result.remaining}/${result.planSize} visits remaining`
           : '';


### PR DESCRIPTION
## Summary
- show success message and optional details in overlay
- use API-provided message for success overlays

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b64881d034832a98d5d73efd00a3da