### PR TITLE
fix: export frog QR image

### DIFF
--- a/web/parent-web/src/assets/frog.ts
+++ b/web/parent-web/src/assets/frog.ts
@@ -53,6 +53,7 @@ export const frogSvg = `<?xml version="1.0" encoding="UTF-8"?>
 
 // Data URL for use in <img src=...> or QR renderers expecting an image string
 export const frogDataUrl: string = `data:image/svg+xml;utf8,${encodeURIComponent(frogSvg)}`;
+export default frogDataUrl;
 
 // Utility to build a sized HTMLImageElement (optional helper)
 export function makeFrogImage(size: number = 128): HTMLImageElement {


### PR DESCRIPTION
## Summary
- default-export frogDataUrl to use as QR logo

## Testing
- `npm test`
- `npm run build`
- `npm test` (web/kiosk-pwa)
- `npm run build` (web/kiosk-pwa)


------
https://chatgpt.com/codex/tasks/task_e_68b64e6a0188832a98c08ff4519015be