### PR TITLE
feat: use frog emoji for child

### DIFF
--- a/web/admin-portal/src/components/ui/SellPassForm.tsx
+++ b/web/admin-portal/src/components/ui/SellPassForm.tsx
@@ -266,13 +266,13 @@ export default function SellPassForm({ open, onClose, onSuccess, preselectedClie
                   )}
                 </div>
                 <div className={styles.selectedClientChild}>
-                  <span>👶</span>
+                  <span>🐸</span>
                   {selectedClient.childName}
                 </div>
                 {preselectedClient && (
-                  <div style={{ 
-                    fontSize: '0.75rem', 
-                    color: 'var(--muted)', 
+                  <div style={{
+                    fontSize: '0.75rem',
+                    color: 'var(--muted)',
                     marginTop: '0.5rem',
                     fontStyle: 'italic'
                   }}>
@@ -310,7 +310,7 @@ export default function SellPassForm({ open, onClose, onSuccess, preselectedClie
                             {client.parentName}
                           </div>
                           <div className={styles.clientChild}>
-                            <span>👶</span>
+                            <span>🐸</span>
                             {client.childName}
                           </div>
                         </div>

--- a/web/admin-portal/src/pages/Clients.tsx
+++ b/web/admin-portal/src/pages/Clients.tsx
@@ -114,7 +114,7 @@ export default function Clients() {
               gap: '0.5rem',
             }}
           >
-            <span>👶</span>
+            <span>🐸</span>
             {client.childName}
           </div>
         </div>

--- a/web/admin-portal/src/pages/Passes.tsx
+++ b/web/admin-portal/src/pages/Passes.tsx
@@ -105,7 +105,7 @@ export default function Passes() {
             alignItems: 'center',
             gap: '0.5rem'
           }}>
-            <span>👶</span>
+            <span>🐸</span>
             {pass.client.childName}
           </div>
         </div>

--- a/web/admin-portal/src/pages/Redeems.tsx
+++ b/web/admin-portal/src/pages/Redeems.tsx
@@ -108,7 +108,7 @@ export default function Redeems() {
                 alignItems: 'center',
                 gap: '0.5rem'
               }}>
-                <span>👶</span>
+                <span>🐸</span>
                 {redeem.client.childName}
               </div>
             </>

--- a/web/parent-web/src/components/PassCard.tsx
+++ b/web/parent-web/src/components/PassCard.tsx
@@ -120,7 +120,7 @@ export default function PassCard({ data, promoContent = [] }: PassCardProps) {
         </div>
         <h1 className={styles.clientName}>{data.name}</h1>
         <p className={styles.childName}>
-          <span>👶</span>
+          <span>🐸</span>
           {data.childName}
         </p>
       </div>


### PR DESCRIPTION
## Summary
- replace baby emoji with frog for child name display in admin portal
- update parent web pass card to show frog emoji near child's name

## Testing
- `cd web/admin-portal && npm test` *(fails: Missing script: "test")*
- `cd web/admin-portal && npm run lint`
- `cd web/parent-web && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b664a57ea0832aaa0093247bbceacc