### PR TITLE
Add admin actions for pass adjustments

### DIFF
--- a/web/admin-portal/src/components/ui/ClientForm.module.css
+++ b/web/admin-portal/src/components/ui/ClientForm.module.css
@@ -855,6 +855,28 @@
   box-shadow: 0 8px 24px rgba(74, 214, 255, 0.4);
 }
 
+.passActions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.passActionButton {
+  background: var(--panel);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.passActionButton:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 .addIcon {
   font-size: 1.25rem;
   font-weight: bold;

--- a/web/admin-portal/src/components/ui/ClientForm.tsx
+++ b/web/admin-portal/src/components/ui/ClientForm.tsx
@@ -7,6 +7,8 @@ import {
   listPasses,
   fetchSettings,
   type SettingsResponse,
+  convertLastVisit,
+  deductPassSessions,
 } from '../../lib/api';
 import styles from './ClientForm.module.css';
 import type { PassWithClient, Client as ApiClient } from '../../types';
@@ -169,6 +171,28 @@ export default function ClientForm({
   const handleSellPassSuccess = async () => {
     if (initial?.id) {
       await loadClientPasses(initial.id as string);
+    }
+  };
+
+  const handleConvertLastVisit = async (passId: string) => {
+    try {
+      await convertLastVisit(passId);
+      if (initial?.id) await loadClientPasses(initial.id as string);
+    } catch (err) {
+      console.error('Failed to convert last visit:', err);
+    }
+  };
+
+  const handleDeductSessions = async (passId: string) => {
+    const input = prompt(t('deductSessions'));
+    if (!input) return;
+    const count = Number(input);
+    if (!count || count <= 0) return;
+    try {
+      await deductPassSessions(passId, count);
+      if (initial?.id) await loadClientPasses(initial.id as string);
+    } catch (err) {
+      console.error('Failed to deduct sessions:', err);
     }
   };
 
@@ -813,10 +837,26 @@ export default function ClientForm({
                           </div>
                         </div>
                         <div className={styles.passProgress}>
-                          <div 
+                          <div
                             className={styles.passProgressBar}
                             style={{ width: `${(pass.remaining / pass.planSize) * 100}%` }}
                           />
+                        </div>
+                        <div className={styles.passActions}>
+                          <button
+                            type="button"
+                            className={styles.passActionButton}
+                            onClick={() => handleConvertLastVisit(pass.id)}
+                          >
+                            {t('convertLastVisit')}
+                          </button>
+                          <button
+                            type="button"
+                            className={styles.passActionButton}
+                            onClick={() => handleDeductSessions(pass.id)}
+                          >
+                            {t('deductSessions')}
+                          </button>
                         </div>
                       </div>
                     ))}

--- a/web/admin-portal/src/lib/i18n.ts
+++ b/web/admin-portal/src/lib/i18n.ts
@@ -95,6 +95,8 @@ export interface Translations {
   loadingPasses: string;
   noActivePassesFound: string;
   sellNewPass: string;
+  convertLastVisit: string;
+  deductSessions: string;
 
   // Passes
   passesTitle: string;
@@ -344,6 +346,8 @@ const translations: Record<Language, Translations> = {
     loadingPasses: 'Загрузка абонементов...',
     noActivePassesFound: 'Активные абонементы не найдены',
     sellNewPass: 'Продать новый абонемент',
+    convertLastVisit: 'Конвертировать последнее посещение',
+    deductSessions: 'Списать занятия',
 
     // Passes
     passesTitle: 'Абонементы',
@@ -591,6 +595,8 @@ const translations: Record<Language, Translations> = {
     loadingPasses: 'Loading passes...',
     noActivePassesFound: 'No active passes found',
     sellNewPass: 'Sell New Pass',
+    convertLastVisit: 'Convert Last Visit',
+    deductSessions: 'Deduct Sessions',
 
     // Passes
     passesTitle: 'Passes',


### PR DESCRIPTION
## Summary
- allow converting client's last drop-in visit into a subscription usage
- enable manual deduction of sessions from a client's pass
- expose UI controls in admin portal for converting visits and deducting sessions

## Testing
- `npm test` (services/core-api)
- `npm test` *(fails: Missing script: "test" in web/admin-portal)*
- `npm run build` (web/admin-portal)


------
https://chatgpt.com/codex/tasks/task_e_68b77917331c832abf9848f7c71429ae