### PR TITLE
Add pass action translations and clean up API

### DIFF
--- a/web/admin-portal/src/components/ui/ClientForm.tsx
+++ b/web/admin-portal/src/components/ui/ClientForm.tsx
@@ -216,55 +216,6 @@ export default function ClientForm({
     }
   };
 
-  const handleConvertLastVisit = async (passId: string) => {
-    if (passId === 'new') {
-      // No active pass - sell pass first, then convert
-      setConvertAfterSale('new');
-      setShowSellPassForm(true);
-    } else {
-      // Has active pass - convert directly
-      const activePass = passes.find(p => p.id === passId && p.remaining > 0);
-      if (activePass) {
-        if (!confirm('Конвертировать последнее разовое посещение в использование абонемента? Это действие нельзя отменить.')) {
-          return;
-        }
-        
-        try {
-          await performConversion(passId);
-        } catch (err) {
-          alert('Ошибка при конвертации посещения. Проверьте, что у клиента есть недавнее разовое посещение.');
-        }
-      }
-    }
-  };
-  const handleDeductSessions = async (passId: string) => {
-    const input = prompt('Введите количество занятий для списания:');
-    if (!input) return;
-    
-    const count = Number(input);
-    if (!count || count <= 0 || !Number.isInteger(count)) {
-      alert('Пожалуйста, введите корректное положительное число.');
-      return;
-    }
-    
-    const pass = passes.find(p => p.id === passId);
-    if (pass && count > pass.remaining) {
-      alert(`Нельзя списать больше занятий (${count}), чем осталось в абонементе (${pass.remaining}).`);
-      return;
-    }
-    
-    if (!confirm(`Списать ${count} ${count === 1 ? 'занятие' : count < 5 ? 'занятия' : 'занятий'} с абонемента? Это действие нельзя отменить.`)) {
-      return;
-    }
-    
-    try {
-      await deductPassSessions(passId, count);
-      if (initial?.id) await loadClientPasses(initial.id as string);
-    } catch (err) {
-      console.error('Failed to deduct sessions:', err);
-      alert('Ошибка при списании занятий. Попробуйте еще раз.');
-    }
-  };
 
   const generateTicketCard = async (url: string, parentName: string, childName: string) => {
     if (!ticketCanvasRef.current) return;

--- a/web/admin-portal/src/lib/api.ts
+++ b/web/admin-portal/src/lib/api.ts
@@ -235,7 +235,6 @@ export async function createPass(body: {
       client,
     });
     
-    return { status: 'created', passId: newPass.id };
     return { status: 'created' };
   }
 

--- a/web/admin-portal/src/lib/i18n.ts
+++ b/web/admin-portal/src/lib/i18n.ts
@@ -104,6 +104,22 @@ export interface Translations {
   expiredStatus: string;
   daysShort: string;
 
+  // Pass Actions
+  convertLastVisitTitle: string;
+  convertLastVisitDescription: string;
+  convertVisit: string;
+  deductSessionsTitle: string;
+  deductSessionsDescription: string;
+  sessionsRemaining: string;
+  importantNote: string;
+  convertWarningText: string;
+  sessionsToDeduct: string;
+  maxSessions: string;
+  currentRemaining: string;
+  toDeduct: string;
+  afterDeduction: string;
+  processing: string;
+
   // Passes
   passesTitle: string;
   sellPass: string;
@@ -360,6 +376,22 @@ const translations: Record<Language, Translations> = {
     activeStatus: 'Активен',
     expiredStatus: 'Исчерпан',
     daysShort: 'дн.',
+
+    // Pass Actions
+    convertLastVisitTitle: 'Конвертировать посещение',
+    convertLastVisitDescription: 'Конвертировать последнее разовое посещение этого клиента в использование абонемента',
+    convertVisit: 'Конвертировать посещение',
+    deductSessionsTitle: 'Списать занятия',
+    deductSessionsDescription: 'Вручную списать занятия с абонемента клиента',
+    sessionsToDeduct: 'Количество занятий для списания',
+    maxSessions: 'Максимум',
+    currentRemaining: 'Сейчас осталось',
+    toDeduct: 'Списать',
+    afterDeduction: 'После списания',
+    sessionsRemaining: 'занятий осталось',
+    importantNote: 'Важное примечание',
+    convertWarningText: 'Это действие найдет последнее разовое посещение клиента и конвертирует его в использование абонемента. Отменить нельзя.',
+    processing: 'Обработка...',
 
     // Passes
     passesTitle: 'Абонементы',


### PR DESCRIPTION
## Summary
- extend translation typings and Russian strings for pass action dialog
- remove unused handlers and tidy createPass mock return

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7b5c585c0832a942190fa217aadde