### PR TITLE
Enable child name search for clients

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -9,6 +9,15 @@
       ]
     },
     {
+      "collectionGroup": "clients",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "searchTokens", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "active", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "passes",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
## Summary
- generate reusable search tokens from parent and child names when clients are created, imported, or updated
- query admin client listings by the tokenized search index so child names are matched
- declare the Firestore composite index required for the new token-based search filter

## Testing
- npm test --prefix services/core-api

------
https://chatgpt.com/codex/tasks/task_e_68de322a500c832a89024a570c3391c1