### PR TITLE
Fix client search to rely on API filtering

### DIFF
--- a/web/admin-portal/src/components/ui/SellPassForm.tsx
+++ b/web/admin-portal/src/components/ui/SellPassForm.tsx
@@ -117,12 +117,6 @@ export default function SellPassForm({ open, onClose, onSuccess, preselectedClie
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  const normalize = (s: string) =>
-    s
-      .normalize('NFD')
-      .replace(/\p{Diacritic}/gu, '')
-      .toLowerCase();
-
   const searchClients = async (term: string) => {
     try {
       setLoadingClients(true);
@@ -133,12 +127,7 @@ export default function SellPassForm({ open, onClose, onSuccess, preselectedClie
         pageSize: 50,
         orderBy: 'parentName',
       });
-      const searchLower = normalize(term);
-      const filtered = data.items.filter(c =>
-        normalize(c.parentName).includes(searchLower) ||
-        normalize(c.childName).includes(searchLower),
-      );
-      setClients(filtered);
+      setClients(data.items);
       setShowDropdown(true);
     } catch (err) {
       console.error('Failed to search clients:', err);

--- a/web/admin-portal/src/pages/Clients.tsx
+++ b/web/admin-portal/src/pages/Clients.tsx
@@ -23,12 +23,6 @@ export default function Clients() {
     loadClients();
   }, [searchTerm, activeFilter]);
 
-  const normalize = (s: string) =>
-    s
-      .normalize('NFD')
-      .replace(/\p{Diacritic}/gu, '')
-      .toLowerCase();
-
   const loadClients = async (token?: string) => {
     try {
       setLoading(true);
@@ -39,14 +33,7 @@ export default function Clients() {
         pageToken: token,
         pageSize: 20
       });
-      const needle = trimmedSearch ? normalize(trimmedSearch) : null;
-      const items = needle
-        ? data.items.filter(client =>
-            normalize(client.parentName).includes(needle) ||
-            normalize(client.childName).includes(needle)
-          )
-        : data.items;
-      setClients(items);
+      setClients(data.items);
       setHasNextPage(!!data.nextPageToken);
       setPageToken(data.nextPageToken);
       setError(null);


### PR DESCRIPTION
## Summary
- remove client-side filtering from the admin client list so server-side search results are respected
- rely on the API response for Sell Pass form client search to allow database-backed lookups

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1d070f94c832aa1dade2d6fd4e0da