### PR TITLE
Ensure database integrity check reinstalls dependencies

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -206,6 +206,9 @@ steps:
     args:
       - -c
       - |
+        echo "📦 Ensuring dependencies are installed for verification..."
+        npm ci
+
         echo "🔍 Verifying database integrity before deployment..."
         export GOOGLE_CLOUD_PROJECT=$PROJECT_ID
         export FIRESTORE_DATABASE_ID=$_FIRESTORE_DATABASE_ID


### PR DESCRIPTION
## Summary
- run `npm ci` in the Cloud Build database verification step to guarantee required dependencies like `object-hash` are present
- add a log message describing the additional installation step before verification starts

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_690a000071cc832aacdbfad89822123e