### PR TITLE
Allow integrity verification warnings without blocking deployments

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -220,7 +220,17 @@ steps:
           exit 1
         fi
 
-        echo "✅ Database verification PASSED - deployment can proceed"
+        REPORT_PATH="reports/integrity-report-latest.json"
+        if [ -f "$REPORT_PATH" ]; then
+          TOTAL_ISSUES=$(node -e "const report = require('./$REPORT_PATH'); process.stdout.write(String(report?.summary?.totalIssues ?? 0));")
+          if [ "$TOTAL_ISSUES" -gt 0 ]; then
+            echo "⚠️ Database verification completed with $TOTAL_ISSUES issues. Deployment will continue."
+          else
+            echo "✅ Database verification PASSED - deployment can proceed"
+          fi
+        else
+          echo "⚠️ Database verification completed but no summary report was found. Deployment will continue; please review the build logs."
+        fi
     waitFor: ['quality-gate-core-api-build']
 
   # ============================================================

--- a/services/core-api/scripts/verify-data-integrity.ts
+++ b/services/core-api/scripts/verify-data-integrity.ts
@@ -577,16 +577,24 @@ async function main() {
       fs.mkdirSync(outputDir, { recursive: true });
     }
 
-    const outputFile = path.join(
-      outputDir,
-      `integrity-report-${new Date().toISOString().replace(/[:.]/g, '-')}.json`,
-    );
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const outputFile = path.join(outputDir, `integrity-report-${timestamp}.json`);
     fs.writeFileSync(outputFile, JSON.stringify(report, null, 2));
     console.log(`📄 Full report saved to: ${outputFile}`);
+
+    const latestReportFile = path.join(outputDir, 'integrity-report-latest.json');
+    fs.writeFileSync(latestReportFile, JSON.stringify(report, null, 2));
+    console.log(`📄 Latest report snapshot saved to: ${latestReportFile}`);
     console.log('');
 
-    // Exit with appropriate code
-    process.exit(report.summary.totalIssues === 0 ? 0 : 1);
+    // Don't fail deployments when issues are detected. Instead, surface a
+    // prominent warning so the report can be reviewed while allowing the
+    // pipeline to continue.
+    if (report.summary.totalIssues > 0) {
+      console.warn(
+        '⚠️  Database integrity issues detected. Review the report but deployment will continue.',
+      );
+    }
   } catch (error) {
     console.error('❌ Error during verification:', error);
     process.exit(1);


### PR DESCRIPTION
## Summary
- update the data integrity verification script to emit warnings while keeping the build green and publish a latest report snapshot
- adjust the Cloud Build database verification step to consume the generated report and continue deployment when issues are detected

## Testing
- not run (requires Firestore environment variables and credentials)


------
https://chatgpt.com/codex/tasks/task_e_690a030f4d18832a9b4343b5f1813d95