### PR TITLE
Gracefully terminate Firestore client after integrity verification

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -220,9 +220,9 @@ steps:
           exit 1
         fi
 
-        REPORT_PATH="reports/integrity-report-latest.json"
-        if [ -f "$REPORT_PATH" ]; then
-          TOTAL_ISSUES=$(node -e "const report = require('./$REPORT_PATH'); process.stdout.write(String(report?.summary?.totalIssues ?? 0));")
+        INTEGRITY_REPORT_FILE="${_INTEGRITY_REPORT_FILE:-reports/integrity-report-latest.json}"
+        if [ -f "$INTEGRITY_REPORT_FILE" ]; then
+          TOTAL_ISSUES=$(node -e "const path = require('path'); const target = path.isAbsolute('$INTEGRITY_REPORT_FILE') ? '$INTEGRITY_REPORT_FILE' : path.join(process.cwd(), '$INTEGRITY_REPORT_FILE'); const report = require(target); process.stdout.write(String(report?.summary?.totalIssues ?? 0));")
           if [ "$TOTAL_ISSUES" -gt 0 ]; then
             echo "⚠️ Database verification completed with $TOTAL_ISSUES issues. Deployment will continue."
           else
@@ -363,6 +363,7 @@ options:
 substitutions:
   _REGION: europe-west3
   _FIRESTORE_DATABASE_ID: "zabicedb"
+  _INTEGRITY_REPORT_FILE: "reports/integrity-report-latest.json"
 
 tags:
   - zabicekiosk

--- a/services/core-api/scripts/verify-data-integrity.ts
+++ b/services/core-api/scripts/verify-data-integrity.ts
@@ -597,7 +597,16 @@ async function main() {
     }
   } catch (error) {
     console.error('❌ Error during verification:', error);
-    process.exit(1);
+    process.exitCode = 1;
+  } finally {
+    try {
+      await db.terminate();
+    } catch (shutdownError) {
+      console.warn('⚠️  Failed to terminate Firestore client cleanly:', shutdownError);
+      if (!process.exitCode || process.exitCode === 0) {
+        process.exitCode = 1;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the verify-data-integrity script always terminates the Firestore client when it finishes running
- preserve warning-only behavior for integrity issues while preventing Cloud Build hangs by closing the gRPC channel

## Testing
- npm --prefix services/core-api run lint

------
https://chatgpt.com/codex/tasks/task_e_690a05c0ff3c832aadcf9cb287801ad2