### PR TITLE
Fix Cloud Build integrity report substitution handling

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -220,9 +220,9 @@ steps:
           exit 1
         fi
 
-        INTEGRITY_REPORT_FILE="${_INTEGRITY_REPORT_FILE:-reports/integrity-report-latest.json}"
+        export INTEGRITY_REPORT_FILE="${_INTEGRITY_REPORT_FILE:-reports/integrity-report-latest.json}"
         if [ -f "$INTEGRITY_REPORT_FILE" ]; then
-          TOTAL_ISSUES=$(node -e "const path = require('path'); const target = path.isAbsolute('$INTEGRITY_REPORT_FILE') ? '$INTEGRITY_REPORT_FILE' : path.join(process.cwd(), '$INTEGRITY_REPORT_FILE'); const report = require(target); process.stdout.write(String(report?.summary?.totalIssues ?? 0));")
+          TOTAL_ISSUES=$(node -e "const path = require('path'); const reportPath = process.env.INTEGRITY_REPORT_FILE; const target = path.isAbsolute(reportPath) ? reportPath : path.join(process.cwd(), reportPath); const report = require(target); process.stdout.write(String(report?.summary?.totalIssues ?? 0));")
           if [ "$TOTAL_ISSUES" -gt 0 ]; then
             echo "⚠️ Database verification completed with $TOTAL_ISSUES issues. Deployment will continue."
           else


### PR DESCRIPTION
## Summary
- export the integrity report path so the verification step can pass it to downstream tooling
- read the report location via `process.env` to avoid Cloud Build substitution errors

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_690a090d2b40832a90dd3c3de592613a